### PR TITLE
Fixes to authenticated StashCache config

### DIFF
--- a/configs/Authfile-auth
+++ b/configs/Authfile-auth
@@ -10,8 +10,3 @@ g /osg/ligo /user/ligo rl \
 # User ligo is granted read/lookup for path /
 u ligo /user/ligo lr \
        /          lr
-
-# All users are denied  read/lookup for path /user/ligo
-# All users are granted read/lookup for path /
-u * /user/ligo -rl \
-    /           rl

--- a/configs/xrootd-stashcache-cache-server.cfg
+++ b/configs/xrootd-stashcache-cache-server.cfg
@@ -48,6 +48,9 @@ if named stashcache-cache-server-auth
    xrd.protocol http:8443 libXrdHttp.so
    pss.origin xrootd-local.unl.edu:1094
 
+   # Proxy cert for retrieving data from origin servers
+   setenv X509_USER_PROXY = /tmp/x509up_xrootd
+
    http.cadir /etc/grid-security/certificates
    http.cert /etc/grid-security/xrd/xrdcert.pem
    http.key /etc/grid-security/xrd/xrdkey.pem


### PR DESCRIPTION
- Configure X509 proxy with environment variable
- Authfile privileges are applied in sequence.
  `u * /user/ligo -lr ...` will deny access to `/user/ligo` for everyone.