### PR TITLE
Add support for origin Authfile generation script.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,6 @@ VERSION := 1.0.0
 
 LIBEXEC_FILES := src/xcache-reporter \
                  src/authfile-update \
-                 src/origin-authfile-update \
                  src/renew-proxy
 INSTALL_LIBEXEC_DIR := usr/libexec/xcache
 XROOTD_CONFIG := configs/Authfile-auth \

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,10 @@ VERSION := 1.0.0
 # Other configuration: May need to change for a release
 # ------------------------------------------------------------------------------
 
-LIBEXEC_FILES := src/xcache-reporter
+LIBEXEC_FILES := src/xcache-reporter \
+                 src/authfile-update \
+                 src/origin-authfile-update \
+                 src/renew-proxy
 INSTALL_LIBEXEC_DIR := usr/libexec/xcache
 XROOTD_CONFIG := configs/Authfile-auth \
                  configs/xcache-robots.txt \
@@ -36,6 +39,8 @@ SYSTEMD_UNITS := configs/xrootd-renew-proxy.service \
                  configs/xrootd-renew-proxy.timer \
                  configs/xcache-reporter.service \
                  configs/xcache-reporter.timer \
+                 configs/stash-origin-authfile.service \
+                 configs/stash-origin-authfile.timer \
                  configs/stash-cache-authfile.service \
                  configs/stash-cache-authfile.timer
 
@@ -96,14 +101,17 @@ install:
 	install -p -m 0644 configs/10-stash-cache-overrides.conf $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/xrootd@stash-cache.service.d/
 	mkdir -p $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/xrootd@stash-cache-auth.service.d
 	install -p -m 0644 configs/10-stash-cache-auth-overrides.conf $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/xrootd@stash-cache-auth.service.d/
+	mkdir -p $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/xrootd@stash-origin.service.d
+	install -p -m 0644 configs/10-stash-origin-overrides.conf $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/xrootd@stash-origin.service.d/
+	mkdir -p $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/xrootd@stash-origin-auth.service.d
+	install -p -m 0644 configs/10-stash-origin-auth-overrides.conf $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/xrootd@stash-origin-auth.service.d/
 	# systemd tempfiles
 	mkdir -p $(DESTDIR)/run/stash-cache
 	mkdir -p $(DESTDIR)/run/stash-cache-auth
+	mkdir -p $(DESTDIR)/run/stash-origin
+	mkdir -p $(DESTDIR)/run/stash-origin-auth
 	mkdir -p $(DESTDIR)/usr/lib/tmpfiles.d
-	install -p -m 0644 configs/stash-cache.conf $(DESTDIR)/usr/lib/tmpfiles.d
-	# Authfile updater scripts
-	mkdir -p $(DESTDIR)/$(INSTALL_LIBEXEC_DIR)/
-	install -p -m 0755 src/authfile-update src/renew-proxy $(DESTDIR)/$(INSTALL_LIBEXEC_DIR)/
+	install -p -m 0644 configs/stash-cache.conf configs/stash-origin.conf $(DESTDIR)/usr/lib/tmpfiles.d
 
 $(TARBALL_NAME): $(DIST_FILES)
 	$(eval TEMP_DIR := $(shell mktemp -d -p . $(DIST_DIR_PREFIX)XXXXXXXXXX))

--- a/configs/10-stash-origin-auth-overrides.conf
+++ b/configs/10-stash-origin-auth-overrides.conf
@@ -1,0 +1,11 @@
+
+[Unit]
+
+# Service dependencies:
+# - Make sure the authfile is generated before startup, but make it a softer
+#   dependency: we want to allow Xrootd to restart even if the topology service
+#   is down.
+# - Depends on fetch-crl and the reporter script, but doesn't need these
+#   to finish or succeed for startup.
+Wants=fetch-crl-boot.service fetch-crl-cron.service stash-origin-authfile.service stash-origin-authfile.timer
+After=stash-origin-authfile.service

--- a/configs/10-stash-origin-overrides.conf
+++ b/configs/10-stash-origin-overrides.conf
@@ -1,0 +1,4 @@
+
+[Unit]
+Wants=stash-origin-authfile.service stash-origin-authfile.timer
+After=stash-origin-authfile.service

--- a/configs/config.d/50-stash-origin-authz.cfg
+++ b/configs/config.d/50-stash-origin-authz.cfg
@@ -32,12 +32,22 @@ if named stash-origin-auth
 
    sec.protbind * gsi
 
-   acc.authdb /etc/xrootd/Authfile
+if defined STASH_ORIGIN_AUTHFILE
+   acc.authdb $STASH_ORIGIN_AUTHFILE
+else
+   acc.authdb /run/stash-origin-auth/Authfile
+fi
 
 else if named stash-origin
 
    xrd.allow host *
    sec.protocol  host
    sec.protbind  * none
+
+if defined STASH_ORIGIN_AUTHFILE
+   acc.authdb $STASH_ORIGIN_AUTHFILE
+else
+   acc.authdb /run/stash-origin/Authfile
+fi
 
 fi

--- a/configs/config.d/50-stash-origin-authz.cfg
+++ b/configs/config.d/50-stash-origin-authz.cfg
@@ -35,8 +35,8 @@ if named stash-origin-auth
 fi
 
 # xrootd config does not do nested "unqualified" ifs
-if defined ?STASH_ORIGIN_AUTHFILE && named stash-origin-auth
-   acc.authdb $STASH_ORIGIN_AUTHFILE
+if defined ?StashOriginAuthfile && named stash-origin-auth
+   acc.authdb $StashOriginAuthfile
 # nor negations ("!")
 else if named stash-origin-auth
    acc.authdb /run/stash-origin-auth/Authfile
@@ -53,8 +53,8 @@ if named stash-origin
 fi
 
 # xrootd config does not do nested "unqualified" ifs
-if defined ?STASH_ORIGIN_PUBLIC_AUTHFILE && named stash-origin
-   acc.authdb $STASH_ORIGIN_PUBLIC_AUTHFILE
+if defined ?StashOriginPublicAuthfile && named stash-origin
+   acc.authdb $StashOriginPublicAuthfile
 # nor negations ("!")
 else if named stash-origin
    acc.authdb /run/stash-origin/Authfile

--- a/configs/config.d/50-stash-origin-authz.cfg
+++ b/configs/config.d/50-stash-origin-authz.cfg
@@ -32,22 +32,31 @@ if named stash-origin-auth
 
    sec.protbind * gsi
 
-   if defined ?STASH_ORIGIN_AUTHFILE
-      acc.authdb $STASH_ORIGIN_AUTHFILE
-   else
-      acc.authdb /run/stash-origin-auth/Authfile
-   fi
+fi
 
-else if named stash-origin
+# xrootd config does not do nested "unqualified" ifs
+if defined ?STASH_ORIGIN_AUTHFILE && named stash-origin-auth
+   acc.authdb $STASH_ORIGIN_AUTHFILE
+# nor negations ("!")
+else if named stash-origin-auth
+   acc.authdb /run/stash-origin-auth/Authfile
+fi
+
+
+
+if named stash-origin
 
    xrd.allow host *
    sec.protocol  host
    sec.protbind  * none
 
-   if defined ?STASH_ORIGIN_PUBLIC_AUTHFILE
-      acc.authdb $STASH_ORIGIN_PUBLIC_AUTHFILE
-   else
-      acc.authdb /run/stash-origin/Authfile
-   fi
-
 fi
+
+# xrootd config does not do nested "unqualified" ifs
+if defined ?STASH_ORIGIN_PUBLIC_AUTHFILE && named stash-origin
+   acc.authdb $STASH_ORIGIN_PUBLIC_AUTHFILE
+# nor negations ("!")
+else if named stash-origin
+   acc.authdb /run/stash-origin/Authfile
+fi
+

--- a/configs/config.d/50-stash-origin-authz.cfg
+++ b/configs/config.d/50-stash-origin-authz.cfg
@@ -44,8 +44,8 @@ else if named stash-origin
    sec.protocol  host
    sec.protbind  * none
 
-   if defined STASH_ORIGIN_AUTHFILE
-      acc.authdb $STASH_ORIGIN_AUTHFILE
+   if defined STASH_ORIGIN_PUBLIC_AUTHFILE
+      acc.authdb $STASH_ORIGIN_PUBLIC_AUTHFILE
    else
       acc.authdb /run/stash-origin/Authfile
    fi

--- a/configs/config.d/50-stash-origin-authz.cfg
+++ b/configs/config.d/50-stash-origin-authz.cfg
@@ -32,7 +32,7 @@ if named stash-origin-auth
 
    sec.protbind * gsi
 
-   if defined STASH_ORIGIN_AUTHFILE
+   if defined ?STASH_ORIGIN_AUTHFILE
       acc.authdb $STASH_ORIGIN_AUTHFILE
    else
       acc.authdb /run/stash-origin-auth/Authfile
@@ -44,7 +44,7 @@ else if named stash-origin
    sec.protocol  host
    sec.protbind  * none
 
-   if defined STASH_ORIGIN_PUBLIC_AUTHFILE
+   if defined ?STASH_ORIGIN_PUBLIC_AUTHFILE
       acc.authdb $STASH_ORIGIN_PUBLIC_AUTHFILE
    else
       acc.authdb /run/stash-origin/Authfile

--- a/configs/config.d/50-stash-origin-authz.cfg
+++ b/configs/config.d/50-stash-origin-authz.cfg
@@ -32,11 +32,11 @@ if named stash-origin-auth
 
    sec.protbind * gsi
 
-if defined STASH_ORIGIN_AUTHFILE
-   acc.authdb $STASH_ORIGIN_AUTHFILE
-else
-   acc.authdb /run/stash-origin-auth/Authfile
-fi
+   if defined STASH_ORIGIN_AUTHFILE
+      acc.authdb $STASH_ORIGIN_AUTHFILE
+   else
+      acc.authdb /run/stash-origin-auth/Authfile
+   fi
 
 else if named stash-origin
 
@@ -44,10 +44,10 @@ else if named stash-origin
    sec.protocol  host
    sec.protbind  * none
 
-if defined STASH_ORIGIN_AUTHFILE
-   acc.authdb $STASH_ORIGIN_AUTHFILE
-else
-   acc.authdb /run/stash-origin/Authfile
-fi
+   if defined STASH_ORIGIN_AUTHFILE
+      acc.authdb $STASH_ORIGIN_AUTHFILE
+   else
+      acc.authdb /run/stash-origin/Authfile
+   fi
 
 fi

--- a/configs/stash-cache-authfile.service
+++ b/configs/stash-cache-authfile.service
@@ -5,7 +5,7 @@ Description=StashCache Authfile generator
 User=xrootd
 Group=xrootd
 Type=oneshot
-ExecStart=/usr/libexec/xcache/authfile-update
+ExecStart=/usr/libexec/xcache/authfile-update --cache
 
 [Install]
 WantedBy=multi-user.target

--- a/configs/stash-origin-authfile.service
+++ b/configs/stash-origin-authfile.service
@@ -5,7 +5,7 @@ Description=Origin Authfile generator
 User=xrootd
 Group=xrootd
 Type=oneshot
-ExecStart=/usr/libexec/xcache/origin-authfile-update
+ExecStart=/usr/libexec/xcache/authfile-update --origin
 
 [Install]
 WantedBy=multi-user.target

--- a/configs/stash-origin-authfile.service
+++ b/configs/stash-origin-authfile.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Origin Authfile generator
+
+[Service]
+User=xrootd
+Group=xrootd
+Type=oneshot
+ExecStart=/usr/libexec/xcache/origin-authfile-update
+
+[Install]
+WantedBy=multi-user.target

--- a/configs/stash-origin-authfile.timer
+++ b/configs/stash-origin-authfile.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Origin Authfile generator
+
+[Timer]
+OnBootSec=15m
+OnUnitActiveSec=15m
+RandomizedDelaySec=3m
+Unit=stash-origin-authfile.service
+
+[Install]
+WantedBy=timers.target

--- a/configs/stash-origin.conf
+++ b/configs/stash-origin.conf
@@ -1,0 +1,3 @@
+# The auto-generated authfile will live here
+d /run/stash-origin 0775 xrootd xrootd
+d /run/stash-origin-auth 0775 xrootd xrootd

--- a/rpm/xcache.spec
+++ b/rpm/xcache.spec
@@ -106,6 +106,14 @@ mkdir -p %{buildroot}%{_sysconfdir}/grid-security/xrd
 %config %{_sysconfdir}/xrootd/config.d/50-stash-origin-authz.cfg
 %config %{_sysconfdir}/xrootd/config.d/50-stash-origin-paths.cfg
 %config(noreplace) %{_sysconfdir}/xrootd/config.d/10-origin-site-local.cfg
+%{_libexecdir}/%{name}/origin-authfile-update
+%{_unitdir}/stash-origin-authfile.service
+%{_unitdir}/stash-origin-authfile.timer
+%{_unitdir}/xrootd@stash-origin.service.d/10-stash-origin-overrides.conf
+%{_unitdir}/xrootd@stash-origin-auth.service.d/10-stash-origin-auth-overrides.conf
+%{_tmpfilesdir}/stash-origin.conf
+%attr(0755, xrootd, xrootd) %dir /run/stash-origin/
+%attr(0755, xrootd, xrootd) %dir /run/stash-origin-auth/
 
 %files -n stash-cache
 %config(noreplace) %{_sysconfdir}/xrootd/Authfile-auth

--- a/rpm/xcache.spec
+++ b/rpm/xcache.spec
@@ -38,6 +38,7 @@ Obsoletes: stashcache-daemon < 1.0.0
 Summary: The OSG Data Federation origin server
 
 Requires: %{name}
+Requires: wget
 
 Provides: stashcache-origin-server = %{name}-%{version}
 Obsoletes: stashcache-origin-server < 1.0.0
@@ -57,7 +58,7 @@ Obsoletes: stashcache-origin-server < 1.0.0
 Summary: The OSG data federation cache server
 
 Requires: %{name}
-Requires: curl
+Requires: wget
 Requires: xrootd-lcmaps >= 1.5.1
 Requires: globus-proxy-utils
 

--- a/rpm/xcache.spec
+++ b/rpm/xcache.spec
@@ -106,7 +106,7 @@ mkdir -p %{buildroot}%{_sysconfdir}/grid-security/xrd
 %config %{_sysconfdir}/xrootd/config.d/50-stash-origin-authz.cfg
 %config %{_sysconfdir}/xrootd/config.d/50-stash-origin-paths.cfg
 %config(noreplace) %{_sysconfdir}/xrootd/config.d/10-origin-site-local.cfg
-%{_libexecdir}/%{name}/origin-authfile-update
+%{_libexecdir}/%{name}/authfile-update
 %{_unitdir}/stash-origin-authfile.service
 %{_unitdir}/stash-origin-authfile.timer
 %{_unitdir}/xrootd@stash-origin.service.d/10-stash-origin-overrides.conf

--- a/src/authfile-update
+++ b/src/authfile-update
@@ -1,7 +1,48 @@
 #!/bin/bash
-CACHE_FQDN=${CACHE_FQDN:-$(hostname -f)}
-curl --silent --show-error --fail "https://topology.opensciencegrid.org/stashcache/authfile?cache_fqdn=${CACHE_FQDN}" > /run/stash-cache-auth/Authfile.tmp && \
-mv /run/stash-cache-auth/Authfile.tmp /run/stash-cache-auth/Authfile
-curl --silent --show-error --fail "https://topology.opensciencegrid.org/stashcache/authfile-public?cache_fqdn=$CACHE_FQDN" > /run/stash-cache/Authfile.tmp && \
-mv /run/stash-cache/Authfile.tmp /run/stash-cache/Authfile
+
+fetch () {
+    local src=$1 dst=$2
+    local tmp=$2.tmp
+    rm -f "$tmp"
+    http_code=$(curl --silent --show-error "$src" -o "$tmp" -w "%{http_code}")
+    if [[ $http_code != 200 ]]; then
+        echo >&2 "HTTP $http_code when fetching $src"
+        if [[ -e $tmp ]]; then
+            echo >&2 "File contents:"
+            cat >&2 "$tmp"
+        fi
+        return 1
+    else
+        mv -f "$tmp" "$dst"
+    fi
+}
+
+die_with_usage () {
+    echo >&2 "Usage: $(basename "$0") --cache|--origin"
+    exit 2
+}
+
+if [[ $# -ne 1 ]]; then
+    die_with_usage
+fi
+
+if [[ $1 == --cache ]]; then
+    CACHE_FQDN=${CACHE_FQDN:-$(hostname -f)}
+    ret=0
+    fetch "https://topology.opensciencegrid.org/stashcache/authfile?cache_fqdn=${CACHE_FQDN}"        /run/stash-cache-auth/Authfile
+    ret=$(( $ret | $? ))
+    fetch "https://topology.opensciencegrid.org/stashcache/authfile-public?cache_fqdn=${CACHE_FQDN}" /run/stash-cache/Authfile
+    ret=$(( $ret | $? ))
+    exit $ret
+elif [[ $1 == --origin ]]; then
+    ORIGIN_FQDN=${ORIGIN_FQDN:-$(hostname -f)}
+    ret=0
+    fetch "https://topology.opensciencegrid.org/stashcache/origin-authfile?fqdn=${ORIGIN_FQDN}"        /run/stash-origin-auth/Authfile
+    ret=$(( $ret | $? ))
+    fetch "https://topology.opensciencegrid.org/stashcache/origin-authfile-public?fqdn=${ORIGIN_FQDN}" /run/stash-origin/Authfile
+    ret=$(( $ret | $? ))
+    exit $ret
+else
+    die_with_usage
+fi
 

--- a/src/authfile-update
+++ b/src/authfile-update
@@ -19,6 +19,10 @@ fetch () {
 
 die_with_usage () {
     echo >&2 "Usage: $(basename "$0") --cache|--origin"
+    echo >&2 "Environment variables used:"
+    echo >&2 "CACHE_FQDN        FQDN used for cache authfile query (default `hostname -f`)"
+    echo >&2 "ORIGIN_FQDN       FQDN used for origin authfile query (default `hostname -f`)"
+    echo >&2 "TOPOLOGY          Topology server to get the data from (default https://topology.opensciencegrid.org)"
     exit 2
 }
 
@@ -26,20 +30,22 @@ if [[ $# -ne 1 ]]; then
     die_with_usage
 fi
 
+TOPOLOGY=${TOPOLOGY:-https://topology.opensciencegrid.org}
+
 if [[ $1 == --cache ]]; then
     CACHE_FQDN=${CACHE_FQDN:-$(hostname -f)}
     ret=0
-    fetch "https://topology.opensciencegrid.org/stashcache/authfile?cache_fqdn=${CACHE_FQDN}"        /run/stash-cache-auth/Authfile
+    fetch "${TOPOLOGY}/stashcache/authfile?cache_fqdn=${CACHE_FQDN}"        /run/stash-cache-auth/Authfile
     ret=$(( $ret | $? ))
-    fetch "https://topology.opensciencegrid.org/stashcache/authfile-public?cache_fqdn=${CACHE_FQDN}" /run/stash-cache/Authfile
+    fetch "${TOPOLOGY}/stashcache/authfile-public?cache_fqdn=${CACHE_FQDN}" /run/stash-cache/Authfile
     ret=$(( $ret | $? ))
     exit $ret
 elif [[ $1 == --origin ]]; then
     ORIGIN_FQDN=${ORIGIN_FQDN:-$(hostname -f)}
     ret=0
-    fetch "https://topology.opensciencegrid.org/stashcache/origin-authfile?fqdn=${ORIGIN_FQDN}"        /run/stash-origin-auth/Authfile
+    fetch "${TOPOLOGY}/stashcache/origin-authfile?fqdn=${ORIGIN_FQDN}"        /run/stash-origin-auth/Authfile
     ret=$(( $ret | $? ))
-    fetch "https://topology.opensciencegrid.org/stashcache/origin-authfile-public?fqdn=${ORIGIN_FQDN}" /run/stash-origin/Authfile
+    fetch "${TOPOLOGY}/stashcache/origin-authfile-public?fqdn=${ORIGIN_FQDN}" /run/stash-origin/Authfile
     ret=$(( $ret | $? ))
     exit $ret
 else

--- a/src/authfile-update
+++ b/src/authfile-update
@@ -3,11 +3,17 @@
 fetch () {
     local src=$1 dst=$2
     local tmp=$2.tmp
+    local ret
+
+    if [[ ! -d $(dirname "$dst") ]]; then
+        echo >&2 "Destination directory does not exist"
+        return 1
+    fi
     rm -f "$tmp"
-    http_code=$(curl --silent --show-error "$src" -o "$tmp" -w "%{http_code}")
-    if [[ $http_code != 200 ]]; then
-        echo >&2 "HTTP $http_code when fetching $src"
-        if [[ -e $tmp ]]; then
+    wget "$src" -q --content-on-error -O "$tmp"; ret=$?
+    if [[ $ret != 0 ]]; then
+        echo >&2 "Error fetching $src"
+        if [[ -s $tmp ]]; then
             echo >&2 "File contents:"
             cat >&2 "$tmp"
         fi

--- a/src/origin-authfile-update
+++ b/src/origin-authfile-update
@@ -1,7 +1,7 @@
 #!/bin/bash
 ORIGIN_FQDN=${ORIGIN_FQDN:-$(hostname -f)}
-curl --silent --show-error --fail "https://topology.opensciencegrid.org/stashcache/origin-authfile?fqdn=${ORIGIN_FQDN}" > /run/stash-origin-auth/Authfile.tmp && \
+curl --silent --show-error --fail "https://topology.opensciencegrid.org/stashcache/origin-authfile?fqdn=${ORIGIN_FQDN}" -o /run/stash-origin-auth/Authfile.tmp && \
 mv /run/stash-origin-auth/Authfile.tmp /run/stash-origin-auth/Authfile
-curl --silent --show-error --fail "https://topology.opensciencegrid.org/stashcache/origin-authfile-public?fqdn=${ORIGIN_FQDN}" > /run/stash-origin/Authfile.tmp && \
+curl --silent --show-error --fail "https://topology.opensciencegrid.org/stashcache/origin-authfile-public?fqdn=${ORIGIN_FQDN}" -o /run/stash-origin/Authfile.tmp && \
 mv /run/stash-origin/Authfile.tmp /run/stash-origin/Authfile
 

--- a/src/origin-authfile-update
+++ b/src/origin-authfile-update
@@ -1,0 +1,7 @@
+#!/bin/bash
+ORIGIN_FQDN=${ORIGIN_FQDN:-$(hostname -f)}
+curl --silent --show-error --fail "https://topology.opensciencegrid.org/stashcache/origin-authfile?fqdn=${ORIGIN_FQDN}" > /run/stash-origin-auth/Authfile.tmp && \
+mv /run/stash-origin-auth/Authfile.tmp /run/stash-origin-auth/Authfile
+curl --silent --show-error --fail "https://topology.opensciencegrid.org/stashcache/origin-authfile-public?fqdn=${ORIGIN_FQDN}" > /run/stash-origin/Authfile.tmp && \
+mv /run/stash-origin/Authfile.tmp /run/stash-origin/Authfile
+

--- a/src/origin-authfile-update
+++ b/src/origin-authfile-update
@@ -1,7 +1,8 @@
 #!/bin/bash
 ORIGIN_FQDN=${ORIGIN_FQDN:-$(hostname -f)}
-curl --silent --show-error --fail "https://topology.opensciencegrid.org/stashcache/origin-authfile?fqdn=${ORIGIN_FQDN}" -o /run/stash-origin-auth/Authfile.tmp && \
+# -k needed to avoid error due to not having a client cert
+curl -k --silent --show-error --fail "https://topology.opensciencegrid.org/stashcache/origin-authfile?fqdn=${ORIGIN_FQDN}" -o /run/stash-origin-auth/Authfile.tmp && \
 mv /run/stash-origin-auth/Authfile.tmp /run/stash-origin-auth/Authfile
-curl --silent --show-error --fail "https://topology.opensciencegrid.org/stashcache/origin-authfile-public?fqdn=${ORIGIN_FQDN}" -o /run/stash-origin/Authfile.tmp && \
+curl -k --silent --show-error --fail "https://topology.opensciencegrid.org/stashcache/origin-authfile-public?fqdn=${ORIGIN_FQDN}" -o /run/stash-origin/Authfile.tmp && \
 mv /run/stash-origin/Authfile.tmp /run/stash-origin/Authfile
 

--- a/src/origin-authfile-update
+++ b/src/origin-authfile-update
@@ -1,7 +1,0 @@
-#!/bin/bash
-ORIGIN_FQDN=${ORIGIN_FQDN:-$(hostname -f)}
-curl --silent --show-error --fail "https://topology.opensciencegrid.org/stashcache/origin-authfile?fqdn=${ORIGIN_FQDN}" -o /run/stash-origin-auth/Authfile.tmp && \
-mv /run/stash-origin-auth/Authfile.tmp /run/stash-origin-auth/Authfile
-curl --silent --show-error --fail "https://topology.opensciencegrid.org/stashcache/origin-authfile-public?fqdn=${ORIGIN_FQDN}" -o /run/stash-origin/Authfile.tmp && \
-mv /run/stash-origin/Authfile.tmp /run/stash-origin/Authfile
-

--- a/src/origin-authfile-update
+++ b/src/origin-authfile-update
@@ -1,8 +1,7 @@
 #!/bin/bash
 ORIGIN_FQDN=${ORIGIN_FQDN:-$(hostname -f)}
-# -k needed to avoid error due to not having a client cert
-curl -k --silent --show-error --fail "https://topology.opensciencegrid.org/stashcache/origin-authfile?fqdn=${ORIGIN_FQDN}" -o /run/stash-origin-auth/Authfile.tmp && \
+curl --silent --show-error --fail "https://topology.opensciencegrid.org/stashcache/origin-authfile?fqdn=${ORIGIN_FQDN}" -o /run/stash-origin-auth/Authfile.tmp && \
 mv /run/stash-origin-auth/Authfile.tmp /run/stash-origin-auth/Authfile
-curl -k --silent --show-error --fail "https://topology.opensciencegrid.org/stashcache/origin-authfile-public?fqdn=${ORIGIN_FQDN}" -o /run/stash-origin/Authfile.tmp && \
+curl --silent --show-error --fail "https://topology.opensciencegrid.org/stashcache/origin-authfile-public?fqdn=${ORIGIN_FQDN}" -o /run/stash-origin/Authfile.tmp && \
 mv /run/stash-origin/Authfile.tmp /run/stash-origin/Authfile
 


### PR DESCRIPTION
This is the origin-side support for https://github.com/opensciencegrid/topology/pull/335.  With this, the origin server can generate its Authfile solely from topology data.