### PR TITLE
Use rootdir instead of origindir and cachedir; ship common site cfg

### DIFF
--- a/configs/stash-cache/config.d/40-osg-xcache.cfg
+++ b/configs/stash-cache/config.d/40-osg-xcache.cfg
@@ -33,7 +33,7 @@ fi
 
 # Set the location of the cache directory to the one specified in the
 # local site configuration.
-oss.localroot $(cachedir)
+oss.localroot $(rootdir)
 
 # Cache plugin parameters
 #

--- a/configs/stash-origin/config.d/10-origin-site-local.cfg
+++ b/configs/stash-origin/config.d/10-origin-site-local.cfg
@@ -13,21 +13,9 @@
 # They have been purposely commented out to cause the server to
 # fail to start unless you edit them.
 
-# A local directory containing files to export from the origin.
-# Must be readable by the xrootd user.
-#
-# set origindir = /mnt/stash
-
 # A directory *relative to origindir* that is the top of the
 # exported namespace.  If files are stored locally in `/mnt/stash/VO`,
-# `origindir` is set to `/mnt/stash`, and `originexport` is `/VO`,
+# `rootdir` is set to `/mnt/stash`, and `originexport` is `/VO`,
 # then clients can access the files within the namespace `/VO`.
 #
 # set originexport = /VO
-
-# The server name to use for monitoring and reporting; this should
-# match the registered resource name in topology.opensciencegrid.org.
-# See https://github.com/opensciencegrid/topology/#topology
-#
-# set sitename = OSG_RESOURCE_NAME
-

--- a/configs/stash-origin/config.d/50-stash-origin-paths.cfg
+++ b/configs/stash-origin/config.d/50-stash-origin-paths.cfg
@@ -9,7 +9,7 @@
 # https://opensciencegrid.org/docs/data/stashcache/overview/
 
 # The directory on local disk containing the files to share, e.g. "/stash".
-oss.localroot $(origindir)
+oss.localroot $(rootdir)
 
 # The directory under oss.localroot to share data from.
 # To share multiple subdirectories, have one `all.export` line per

--- a/configs/xcache/config.d/10-common-site-local.cfg
+++ b/configs/xcache/config.d/10-common-site-local.cfg
@@ -1,23 +1,25 @@
 #
 # Site-provided default values that are necessary for
-# variable substitutions in the OSG config files.
+# variable substitutions in the OSG XCache config files.
 #
 # ************************************************************
 # * NOTE: Changes to this file will be PRESERVED on upgrades *
 # ************************************************************
 #
-# This file is part of the StashCache Daemon
-# https://opensciencegrid.org/docs/data/stashcache/overview/
+# This file is part of the XCache packaging
 
 # You MUST uncomment and fill ALL variables below.
 # They have been purposely commented out to cause the server to
 # fail to start unless you edit them.
 
-# A local directory where the daemon can write its cache files.
+# A local directory containing files to export from the cache or origin.
+# For caches:
 # - Must be writable by the xrootd user.
 # - OSG recommends this be at least 1TB.
+# For origins:
+# - Must be readable by the xrootd user.
 #
-# set cachedir = /mnt/stash
+# set rootdir = /stash
 
 # The server name to use for monitoring and reporting; this should
 # match the registered resource name in topology.opensciencegrid.org.

--- a/rpm/xcache.spec
+++ b/rpm/xcache.spec
@@ -97,6 +97,7 @@ mkdir -p %{buildroot}%{_sysconfdir}/grid-security/xrd
 %{python_sitelib}/xrootd_cache_stats.py*
 %{_unitdir}/xcache-reporter.service
 %{_unitdir}/xcache-reporter.timer
+%config(noreplace) %{_sysconfdir}/xrootd/config.d/10-common-site-local.cfg
 %config %{_sysconfdir}/xrootd/config.d/40-osg-monitoring.cfg
 %config %{_sysconfdir}/xrootd/config.d/40-osg-paths.cfg
 %config(noreplace) %{_sysconfdir}/xrootd/config.d/90-xcache-logging.cfg
@@ -126,7 +127,6 @@ mkdir -p %{buildroot}%{_sysconfdir}/grid-security/xrd
 %config %{_sysconfdir}/xrootd/config.d/40-osg-http.cfg
 %config %{_sysconfdir}/xrootd/config.d/40-osg-xcache.cfg
 %config %{_sysconfdir}/xrootd/config.d/50-stash-cache-authz.cfg
-%config(noreplace) %{_sysconfdir}/xrootd/config.d/10-cache-site-local.cfg
 %{_libexecdir}/%{name}/authfile-update
 %{_libexecdir}/%{name}/renew-proxy
 %{_unitdir}/xrootd-renew-proxy.service


### PR DESCRIPTION
Other common config that can go here: `# set DisableOsgMonitoring = 1` so XCache implementations can override the OSG monitoring that we ship in `40-osg-monitoring.cfg`. I'll make another PR for that.