### PR TITLE
Support for VOMS proxies

### DIFF
--- a/rpm/xcache.spec
+++ b/rpm/xcache.spec
@@ -14,11 +14,13 @@ BuildRequires: systemd
 # Necessary for daemon to report back to the OSG Collector.
 Requires: condor-python
 Requires: python-xrootd
+Requires: voms-clients-cpp
 
 # We utilize a configuration directive (`continue`) introduced in XRootD 4.9.
 Requires: xrootd-server >= 1:4.9.0
 
 Requires: grid-certificates >= 7
+Requires: vo-client
 Requires: fetch-crl
 
 Provides: stashcache-daemon = %{name}-%{version}

--- a/rpm/xcache.spec
+++ b/rpm/xcache.spec
@@ -30,11 +30,11 @@ Obsoletes: stashcache-daemon < 1.0.0
 %{summary}
 
 %post
-%systemd_post xcache-reporter.service xcache-reporter.timer
+%systemd_post xcache-reporter.service xcache-reporter.timer xrootd-renew-proxy.service xrootd-renew-proxy.timer
 %preun
-%systemd_preun xcache-reporter.service xcache-reporter.timer
+%systemd_preun xcache-reporter.service xcache-reporter.timer xrootd-renew-proxy.service xrootd-renew-proxy.timer
 %postun
-%systemd_postun_with_restart xcache-reporter.service xcache-reporter.timer
+%systemd_postun_with_restart xcache-reporter.service xcache-reporter.timer xrootd-renew-proxy.service xrootd-renew-proxy.timer
 
 ########################################
 %package -n stash-origin
@@ -64,7 +64,6 @@ Summary: The OSG data federation cache server
 Requires: %{name}
 Requires: wget
 Requires: xrootd-lcmaps >= 1.5.1
-Requires: globus-proxy-utils
 
 Provides: stashcache-cache-server = %{name}-%{version}
 Provides: stashcache-cache-server-auth = %{name}-%{version}
@@ -75,11 +74,11 @@ Obsoletes: stashcache-cache-server-auth < 1.0.0
 %{summary}
 
 %post -n stash-cache
-%systemd_post xrootd@stash-cache.service stash-cache-authfile.service stash-cache-authfile.timer xrootd@stash-cache-auth.service xrootd-renew-proxy.service xrootd-renew-proxy.timer
+%systemd_post xrootd@stash-cache.service stash-cache-authfile.service stash-cache-authfile.timer xrootd@stash-cache-auth.service
 %preun -n stash-cache
-%systemd_preun xrootd@stash-cache.service stash-cache-authfile.service stash-cache-authfile.timer xrootd@stash-cache-auth.service xrootd-renew-proxy.service xrootd-renew-proxy.timer
+%systemd_preun xrootd@stash-cache.service stash-cache-authfile.service stash-cache-authfile.timer xrootd@stash-cache-auth.service
 %postun -n stash-cache
-%systemd_postun_with_restart xrootd@stash-cache.service stash-cache-authfile.service stash-cache-authfile.timer xrootd@stash-cache-auth.service xrootd-renew-proxy.service xrootd-renew-proxy.timer
+%systemd_postun_with_restart xrootd@stash-cache.service stash-cache-authfile.service stash-cache-authfile.timer xrootd@stash-cache-auth.service
 
 %prep
 %setup -n %{name}-%{version} -q
@@ -97,9 +96,12 @@ mkdir -p %{buildroot}%{_sysconfdir}/grid-security/xrd
 
 %files
 %{_libexecdir}/%{name}/xcache-reporter
+%{_libexecdir}/%{name}/renew-proxy
 %{python_sitelib}/xrootd_cache_stats.py*
 %{_unitdir}/xcache-reporter.service
 %{_unitdir}/xcache-reporter.timer
+%{_unitdir}/xrootd-renew-proxy.service
+%{_unitdir}/xrootd-renew-proxy.timer
 %config(noreplace) %{_sysconfdir}/xrootd/config.d/10-common-site-local.cfg
 %config %{_sysconfdir}/xrootd/config.d/40-osg-monitoring.cfg
 %config %{_sysconfdir}/xrootd/config.d/40-osg-paths.cfg
@@ -134,9 +136,6 @@ mkdir -p %{buildroot}%{_sysconfdir}/grid-security/xrd
 %config %{_sysconfdir}/xrootd/config.d/50-stash-cache-authz.cfg
 %config %{_sysconfdir}/xrootd/config.d/50-stash-cache-paths.cfg
 %{_libexecdir}/%{name}/authfile-update
-%{_libexecdir}/%{name}/renew-proxy
-%{_unitdir}/xrootd-renew-proxy.service
-%{_unitdir}/xrootd-renew-proxy.timer
 %{_unitdir}/stash-cache-authfile.service
 %{_unitdir}/stash-cache-authfile.timer
 %{_unitdir}/xrootd@stash-cache.service.d/10-stash-cache-overrides.conf

--- a/src/renew-proxy
+++ b/src/renew-proxy
@@ -3,9 +3,10 @@
 HOSTCERT=/etc/grid-security/xrd/xrdcert.pem
 HOSTKEY=/etc/grid-security/xrd/xrdkey.pem
 PROXYFILE=/run/stash-cache-auth/x509_proxy
-/bin/grid-proxy-init -cert "$HOSTCERT" \
+/bin/voms-proxy-init -cert "$HOSTCERT" \
                      -key "$HOSTKEY" \
                      -out "${PROXYFILE}.tmp" \
                      -valid 48:00 \
+                     "$@" \
   &&
 mv "${PROXYFILE}.tmp" "${PROXYFILE}"

--- a/src/renew-proxy
+++ b/src/renew-proxy
@@ -3,7 +3,7 @@
 HOSTCERT=/etc/grid-security/xrd/xrdcert.pem
 HOSTKEY=/etc/grid-security/xrd/xrdkey.pem
 PROXYFILE=/run/stash-cache-auth/x509_proxy
-/bin/voms-proxy-init -cert "$HOSTCERT" \
+/usr/bin/voms-proxy-init -cert "$HOSTCERT" \
                      -key "$HOSTKEY" \
                      -out "${PROXYFILE}.tmp" \
                      -valid 48:00 \


### PR DESCRIPTION
- ATLAS needs VOMS proxies for their auth (https://github.com/slateci/XCache/blob/5d2b3c023ed3c6e845765141637b6dba823e56f5/run_x509_updater.sh#L10-L13).
- All implementations need proxies, at least for the XCache reporter.
    - Do we actually want origins reporting to the central collector?
    - ATLAS XCaches will fail to advertise to the central collector because Ilija's using the same service account cert across all XCaches

If we decide to generate the proxy for all implementations, we need to move the proxy to a different location (`/run/xcache/x509_proxy`?) and make changes to the XRootD config so that `X509_USER_PROXY` is always set.