### PR TITLE
 Separate origin exports into auth and unauth

### DIFF
--- a/configs/stash-origin/config.d/10-origin-site-local.cfg
+++ b/configs/stash-origin/config.d/10-origin-site-local.cfg
@@ -16,15 +16,16 @@
 # A directory *relative to rootdir* that is the top of the
 # exported namespace.  If public files are stored locally
 # in `/mnt/stash/VO/PUBLIC`, `rootdir` is set to `/mnt/stash`,
-# and `originexport` is `/VO/PUBLIC`,
-# then clients can access the files using the public origin
-# within the namespace `/VO/PUBLIC`.
+# and `originexport` is `/VO/PUBLIC`, then clients can access the files
+# using the public origin, within the namespace `/VO/PUBLIC`.
 #
-# Protected files (served only by the authenticated origin)
-# work the same way, except you set `originauthexport`
-# instead of `originexport`.
+# Protected files (served only by the authenticated origin) work the same
+# way, except you set `originauthexport` instead of `originexport`.
 #
-# If you are not using one of the two, leave it blank.
+# If you are not using one of the two, leave it commented out.
+#
+# See https://opensciencegrid.org/docs/data/stashcache/vo-data/ for more
+# information about organizing your VO's data for the StashCache Federation.
 #
 #set originexport = /VO/PUBLIC
 #set originauthexport = /VO/PROTECTED

--- a/configs/stash-origin/config.d/10-origin-site-local.cfg
+++ b/configs/stash-origin/config.d/10-origin-site-local.cfg
@@ -14,8 +14,17 @@
 # fail to start unless you edit them.
 
 # A directory *relative to rootdir* that is the top of the
-# exported namespace.  If files are stored locally in `/mnt/stash/VO`,
-# `rootdir` is set to `/mnt/stash`, and `originexport` is `/VO`,
-# then clients can access the files within the namespace `/VO`.
+# exported namespace.  If public files are stored locally
+# in `/mnt/stash/VO/PUBLIC`, `rootdir` is set to `/mnt/stash`,
+# and `originexport` is `/VO/PUBLIC`,
+# then clients can access the files using the public origin
+# within the namespace `/VO/PUBLIC`.
 #
-# set originexport = /VO
+# Protected files (served only by the authenticated origin)
+# work the same way, except you set `originauthexport`
+# instead of `originexport`.
+#
+# If you are not using one of the two, leave it blank.
+#
+#set originexport = /VO/PUBLIC
+#set originauthexport = /VO/PROTECTED

--- a/configs/stash-origin/config.d/50-stash-origin-paths.cfg
+++ b/configs/stash-origin/config.d/50-stash-origin-paths.cfg
@@ -17,5 +17,8 @@ oss.localroot $(rootdir)
 #
 # NOTE: the StashCache namespace is global; do not share paths that may
 # collide with paths provided by other origin servers.
-all.export $(originexport)
-
+if named stash-origin
+    all.export $(originexport)
+else if named stash-origin-auth
+    all.export $(originauthexport)
+fi


### PR DESCRIPTION
Have separate export paths for the auth and unauth origin, allowing users to run both on the same machine (once we take care of the CMSD issue in [SOFTWARE-3559](https://opensciencegrid.atlassian.net/browse/SOFTWARE-3559).

This should also solve the problems I ran into when setting up both a cache and an origin on the same server (for testing).