### PR TITLE
Add backslashes for line continuation

### DIFF
--- a/configs/stash-cache/overrides/10-stash-cache-auth-overrides.conf
+++ b/configs/stash-cache/overrides/10-stash-cache-auth-overrides.conf
@@ -9,7 +9,7 @@
 # - Depends on fetch-crl and the reporter script, but doesn't need these
 #   to finish or succeed for startup.
 Requires=xrootd-renew-proxy.service
-Wants=fetch-crl-boot.service fetch-crl-cron.service
-      stash-cache-authfile.service stash-cache-authfile.timer
+Wants=fetch-crl-boot.service fetch-crl-cron.service \
+      stash-cache-authfile.service stash-cache-authfile.timer \
       xrootd-renew-proxy.timer xcache-reporter.timer
 After=stash-cache-authfile.service xrootd-renew-proxy.service

--- a/configs/stash-cache/overrides/10-stash-cache-overrides.conf
+++ b/configs/stash-cache/overrides/10-stash-cache-overrides.conf
@@ -8,6 +8,6 @@
 # - Depends on fetch-crl and the reporter script, but doesn't need these
 #   to finish or succeed for startup.
 
-Wants=stash-cache-authfile.service stash-cache-authfile.timer
+Wants=stash-cache-authfile.service stash-cache-authfile.timer \
       xrootd-renew-proxy.timer xcache-reporter.timer
 After=stash-cache-authfile.service xrootd-renew-proxy.service

--- a/configs/stash-origin/overrides/xrootd/10-stash-origin-auth-overrides.conf
+++ b/configs/stash-origin/overrides/xrootd/10-stash-origin-auth-overrides.conf
@@ -8,8 +8,8 @@
 # - Depends on fetch-crl and the reporter script, but doesn't need these
 #   to finish or succeed for startup.
 # - Turn on cmsd; needed to join a federation, but you can shut it off without causing xrootd to turn off also
-Wants=fetch-crl-boot.service fetch-crl-cron.service
-      stash-origin-authfile.service stash-origin-authfile.timer
-      cmsd@%i.service
+Wants=fetch-crl-boot.service fetch-crl-cron.service \
+      stash-origin-authfile.service stash-origin-authfile.timer \
+      cmsd@%i.service \
       xrootd-renew-proxy.timer xcache-reporter.timer
 After=stash-origin-authfile.service xrootd-renew-proxy.service

--- a/configs/stash-origin/overrides/xrootd/10-stash-origin-overrides.conf
+++ b/configs/stash-origin/overrides/xrootd/10-stash-origin-overrides.conf
@@ -7,9 +7,8 @@
 #   is down.
 # - Turn on cmsd; needed to join a federation, but you can shut it off without causing xrootd to turn off also
 
-Wants=stash-origin-authfile.service stash-origin-authfile.timer
-      cmsd@%i.service
+Wants=stash-origin-authfile.service stash-origin-authfile.timer \
+      cmsd@%i.service \
       xrootd-renew-proxy.timer xcache-reporter.timer
-After=stash-origin-authfile.service
+After=stash-origin-authfile.service \
       xrootd-renew-proxy.service
-


### PR DESCRIPTION
As documented in systemd.syntax(7), systemd requires backslashes when
splitting a line into multiple parts.  I don't understand why this
hasn't broken anything in our tests but we ran into it in FD #8513.