### PR TITLE
Update mandatory configuration filename in comments

### DIFF
--- a/configs/stash-cache/xrootd/xrootd-stash-cache.cfg
+++ b/configs/stash-cache/xrootd/xrootd-stash-cache.cfg
@@ -6,7 +6,7 @@
 # **********************************************************************
 #
 # Instead of editing this file,
-# - Edit `/etc/xrootd/config.d/10-cache-site-local.cfg` to provide a few
+# - Edit `/etc/xrootd/config.d/10-common-site-local.cfg` to provide a few
 #   MANDATORY variable values.
 # - Override OSG-provided defaults by dropping a site-specific configuration
 #   file in `/etc/xrootd/config.d` and prefixing it with "90-" or higher.


### PR DESCRIPTION
The main xrootd config file refers to [config.d/10-cache-site-local.cfg](https://github.com/opensciencegrid/xcache/blob/master/configs/stash-cache/xrootd/xrootd-stash-cache.cfg#L9) which does not exist.

The file instead seems to be [config.d/10-common-site-local.cfg](https://github.com/opensciencegrid/xcache/blob/master/configs/xcache/config.d/10-common-site-local.cfg).