### PR TITLE
Fixup authzfunparms and disable lcmaps authz for CMS XCache

### DIFF
--- a/configs/cms-xcache/config.d/50-cms-xcache-authz.cfg
+++ b/configs/cms-xcache/config.d/50-cms-xcache-authz.cfg
@@ -15,7 +15,7 @@ sec.protocol /usr/lib64 gsi \
   -cert:/etc/grid-security/xrd/xrdcert.pem \
   -key:/etc/grid-security/xrd/xrdkey.pem \
   -crl:1 -authzfun:libXrdLcmaps.so \
-  -authzfunparms:lcmapscfg=/etc/xrootd/lcmaps.cfg,loglevel=1 \
+  -authzfunparms:lcmapscfg=/etc/xrootd/lcmaps.cfg,loglevel=1,no-authz \
   -gmapopt:10 -gmapto:0
 
 # The Authorization file for which users can do which actions:

--- a/configs/cms-xcache/config.d/50-cms-xcache-authz.cfg
+++ b/configs/cms-xcache/config.d/50-cms-xcache-authz.cfg
@@ -15,8 +15,7 @@ sec.protocol /usr/lib64 gsi \
   -cert:/etc/grid-security/xrd/xrdcert.pem \
   -key:/etc/grid-security/xrd/xrdkey.pem \
   -crl:1 -authzfun:libXrdLcmaps.so \
-  -authzfunparms:--lcmapscfg=/etc/xrootd/lcmaps.cfg,\
-  --loglevel=1 \
+  -authzfunparms:lcmapscfg=/etc/xrootd/lcmaps.cfg,loglevel=1 \
   -gmapopt:10 -gmapto:0
 
 # The Authorization file for which users can do which actions:

--- a/configs/stash-cache/config.d/50-stash-cache-authz.cfg
+++ b/configs/stash-cache/config.d/50-stash-cache-authz.cfg
@@ -32,7 +32,7 @@ if named stash-cache-auth
      -key:/etc/grid-security/xrd/xrdkey.pem \
      -crl:1 \
      -authzfun:libXrdLcmaps.so \
-     -authzfunparms:--lcmapscfg=/etc/xrootd/lcmaps.cfg,--no-authz \
+     -authzfunparms:lcmapscfg=/etc/xrootd/lcmaps.cfg,no-authz \
      -gmapopt:0 \
      -authzto:3600
    sec.protbind * gsi

--- a/configs/stash-origin/config.d/50-stash-origin-authz.cfg
+++ b/configs/stash-origin/config.d/50-stash-origin-authz.cfg
@@ -26,7 +26,7 @@ if named stash-origin-auth
         -key:/etc/grid-security/xrd/xrdkey.pem \
         -crl:1 \
         -authzfun:libXrdLcmaps.so \
-        -authzfunparms:--lcmapscfg=/etc/xrootd/lcmaps.cfg,--no-authz \
+        -authzfunparms:lcmapscfg=/etc/xrootd/lcmaps.cfg,no-authz \
         -gmapopt:0 \
         -authzto:3600
 


### PR DESCRIPTION
We definitely need the first commit. I believe the second commit is what we wanted for all XCaches (as suggested by @bbockelm)