### PR TITLE
Put auth stash cache/origin on port 1094, unauth on 1095

### DIFF
--- a/configs/stash-cache/xrootd/xrootd-stash-cache.cfg
+++ b/configs/stash-cache/xrootd/xrootd-stash-cache.cfg
@@ -17,8 +17,8 @@
 
 
 # A few extra configuration settings that have no good other location.
-if named stash-cache-auth
-   xrd.port 8443
+if named stash-cache
+   xrd.port 1095
 else
    # non-authed stash-cache; the HTTP plugin will also listen on 8000
    xrd.port 1094

--- a/configs/stash-origin/xrootd/xrootd-stash-origin.cfg
+++ b/configs/stash-origin/xrootd/xrootd-stash-origin.cfg
@@ -23,7 +23,7 @@ all.manager redirector.osgstorage.org+ 1213
 
 
 # A few reasonable defaults for the origin server.
-if named stash-origin-auth
+if named stash-origin
     xrd.port 1095
 else
     xrd.port 1094


### PR DESCRIPTION
ATLAS and CMS use auth and the default XRootD port of 1094.  With the
goal of only shipping a single XCache package that serves all three
data federations, we should unify our ports.

Additionally, we're unifying the HTTP/S and XRootD ports in
osg-xrootd, hence the change from 8443.

This will require changes to clients such as stashcp.