### PR TITLE
Have CMS cache daemons have use the US redirector as their origin

### DIFF
--- a/configs/stash-cache/config.d/40-stash-cache-plugin.cfg
+++ b/configs/stash-cache/config.d/40-stash-cache-plugin.cfg
@@ -22,7 +22,7 @@ if named atlas-xcache
    pss.namelib -lfncache /usr/lib64/XrdName2NameDCP4RUCIO.so
    # Allow new version of RUcio Xcache management 
    pss.ccmlib XrdName2NameDCP4RUCIO.so
-else if exec xrootd && named cms-xcache
+else if named cms-xcache
    pss.origin cmsxrootd.fnal.gov:1094
 
    xrd.network keepalive kaparms 10m,1m,5


### PR DESCRIPTION
Requested by @efajardo on slack