### PR TITLE
Advertise to the central collector via SSL (SOFTWARE-3940)

### DIFF
--- a/configs/xcache/condor/01-xcache-reporter-auth.conf
+++ b/configs/xcache/condor/01-xcache-reporter-auth.conf
@@ -1,0 +1,6 @@
+# Advertise to the central collector with SSL (SOFTWARE-3940)
+SEC_CLIENT_AUTHENTICATION_METHODS = SSL, GSI
+
+AUTH_SSL_CLIENT_CERTFILE = /etc/grid-security/xrd/xrdcert.pem
+AUTH_SSL_CLIENT_KEYFILE=/etc/grid-security/xrd/xrdkey.pem
+AUTH_SSL_CLIENT_CADIR = /etc/grid-security/certificates


### PR DESCRIPTION
Tested this on some Fermicloud VMs along with https://github.com/htcondor/htcondor-ce/pull/300 with both HTCondor 8.8 and 8.9 installed on the stash-cache host.

I'm on the fence about setting the `AUTH_SSL_*` variables to use `/etc/grid-security` because it'd be nice to use standard cert locations but it's annoying for users to have to set these vars manually if they don't have non-GSI certs.