### PR TITLE
Allow setting the path to scitokens.conf

### DIFF
--- a/configs/stash-cache/config.d/50-stash-cache-authz.cfg
+++ b/configs/stash-cache/config.d/50-stash-cache-authz.cfg
@@ -65,6 +65,10 @@ fi
 xrootd.diglib * /etc/xrootd/digauth.cfg
 
 # Allow scitokens on all ports, all protocols
-ofs.authlib libXrdAccSciTokens.so config=/run/stash-cache-auth/scitokens.conf
+if defined ?StashCacheSciTokensConf
+    ofs.authlib libXrdAccSciTokens.so config=$StashCacheSciTokensConf
+else
+    ofs.authlib libXrdAccSciTokens.so config=/run/stash-cache-auth/scitokens.conf
+fi
 # Pass the bearer token to the Xrootd authorization framework.
 http.header2cgi Authorization authz

--- a/configs/stash-origin/config.d/50-stash-origin-authz.cfg
+++ b/configs/stash-origin/config.d/50-stash-origin-authz.cfg
@@ -61,4 +61,8 @@ else if named stash-origin
 fi
 
 # Allow scitokens always, whether auth origin or not.
-ofs.authlib libXrdAccSciTokens.so config=/run/stash-origin-auth/scitokens.conf
+if defined ?StashOriginSciTokensConf
+    ofs.authlib libXrdAccSciTokens.so config=$StashOriginSciTokensConf
+else
+    ofs.authlib libXrdAccSciTokens.so config=/run/stash-origin-auth/scitokens.conf
+fi


### PR DESCRIPTION
We let people do this for the Authfiles; we should let people do this for scitokens too.