### PR TITLE
Update 40-stash-cache-plugin.cfg

### DIFF
--- a/configs/stash-cache/config.d/40-stash-cache-plugin.cfg
+++ b/configs/stash-cache/config.d/40-stash-cache-plugin.cfg
@@ -13,7 +13,7 @@ if exec xrootd
    # Only Xrootd should be using osslib not cmsd
    ofs.osslib  libXrdPss.so
    # Second, the cache underlying the proxy.
-   pss.cachelib libXrdFileCache.so
+   pss.cachelib libXrdPfc.so
 fi
 
 # This is need so the redir does not have to think too much


### PR DESCRIPTION
this is current name of the library. Old one was just a backward compatibility link.