### PR TITLE
Update 40-stash-cache-plugin.cfg

### DIFF
--- a/configs/stash-cache/config.d/40-stash-cache-plugin.cfg
+++ b/configs/stash-cache/config.d/40-stash-cache-plugin.cfg
@@ -29,8 +29,6 @@ if named atlas-xcache
 
    # Load the Rucio namespace-mapping plugin
    pss.namelib -lfncache /usr/lib64/XrdName2NameDCP4RUCIO.so
-   # Allow new version of RUcio Xcache management 
-   pss.ccmlib XrdName2NameDCP4RUCIO.so
 else if named cms-xcache
    pss.origin cmsxrootd.fnal.gov:1094
 


### PR DESCRIPTION
Re: pss.ccmlib, this was a suggestion from Wei on June 26, 2019:

I add an extra line "pss.ccmlib /usr/lib64/XrdName2NameDCP4RUCIO.so" to the config file.  It might be needed in the future. I expect the current Xcache will ignore it. If it causes trouble, please comment it out.

We should have this in only if/when needed and we know what it does.