### PR TITLE
Update 95-atlas-xcache-logging.cfg

### DIFF
--- a/configs/atlas-xcache/config.d/95-atlas-xcache-logging.cfg
+++ b/configs/atlas-xcache/config.d/95-atlas-xcache-logging.cfg
@@ -7,5 +7,6 @@
 #
 # This file is part of the ATLAS XCache Daemon
 
+# Uncomment the following lines for additional debugging
 # pfc.trace info
 # ofs.trace open close delay redirect

--- a/configs/atlas-xcache/config.d/95-atlas-xcache-logging.cfg
+++ b/configs/atlas-xcache/config.d/95-atlas-xcache-logging.cfg
@@ -7,5 +7,5 @@
 #
 # This file is part of the ATLAS XCache Daemon
 
-pfc.trace info
-ofs.trace open close delay redirect
+# pfc.trace info
+# ofs.trace open close delay redirect


### PR DESCRIPTION
Until we have a way to delete logs, we don't want any logging by default. Since logs go into ephemeral storage, as soon as it gets full (<1Gb) server restarts.