### PR TITLE
Update 40-stash-cache-plugin.cfg

### DIFF
--- a/configs/stash-cache/config.d/40-stash-cache-plugin.cfg
+++ b/configs/stash-cache/config.d/40-stash-cache-plugin.cfg
@@ -53,19 +53,19 @@ fi
 if defined ?~XC_BLOCKSIZE
    set eBLOCKSIZE=$XC_BLOCKSIZE
 else
-   set eBLOCKSIZE=512k
+   set eBLOCKSIZE=1M
 fi
 
 if defined ?~XC_PREFETCH
    set ePREFETCH=$XC_PREFETCH
 else
-   set ePREFETCH=10
+   set ePREFETCH=0
 fi
 
 if defined ?~XC_RAMSIZE
    set eRAMSIZE=$XC_RAMSIZE
 else
-   set eRAMSIZE=1g
+   set eRAMSIZE=16g
 fi
 
 if defined ?~XC_SPACE_LOW_WM


### PR DESCRIPTION
I propose these defaults as a bit more sensible. We normally run with 60Gb RAM I don't thing 1g is sufficient for anything. The other two changes are what we found optimal for us. @efajardo, @matyasselmeci would this be OK with you?