### PR TITLE
Update config to append SciTokens to the auth list for XRootD 5+

### DIFF
--- a/configs/stash-cache/config.d/50-stash-cache-authz.cfg
+++ b/configs/stash-cache/config.d/50-stash-cache-authz.cfg
@@ -65,10 +65,17 @@ fi
 xrootd.diglib * /etc/xrootd/digauth.cfg
 
 # Allow scitokens on all ports, all protocols
-if defined ?StashCacheSciTokensConf
+# For XRootD 4, replace the auth lib with SciTokens
+# For XRootD 5+, append SciTokens to the  the auth list
+if defined ?StashCacheSciTokensConf && defined ?~XROOTD4
     ofs.authlib libXrdAccSciTokens.so config=$StashCacheSciTokensConf
-else
+else if defined ?~XROOTD4
     ofs.authlib libXrdAccSciTokens.so config=/run/stash-cache-auth/scitokens.conf
+else if defined ?StashCacheSciTokensConf
+    ofs.authlib +++ libXrdAccSciTokens.so config=$StashCacheSciTokensConf
+else
+    ofs.authlib +++ libXrdAccSciTokens.so config=/run/stash-cache-auth/scitokens.conf
 fi
+
 # Pass the bearer token to the Xrootd authorization framework.
 http.header2cgi Authorization authz

--- a/configs/stash-origin/config.d/50-stash-origin-authz.cfg
+++ b/configs/stash-origin/config.d/50-stash-origin-authz.cfg
@@ -61,8 +61,14 @@ else if named stash-origin
 fi
 
 # Allow scitokens always, whether auth origin or not.
-if defined ?StashOriginSciTokensConf
+# For XRootD 4, replace the auth lib with SciTokens
+# For XRootD 5+, append SciTokens to the  the auth list
+if defined ?StashOriginSciTokensConf && defined ?~XROOTD4
     ofs.authlib libXrdAccSciTokens.so config=$StashOriginSciTokensConf
-else
+else if defined ?~XROOTD4
     ofs.authlib libXrdAccSciTokens.so config=/run/stash-origin-auth/scitokens.conf
+else if defined ?StashOriginSciTokensConf
+    ofs.authlib +++ libXrdAccSciTokens.so config=$StashOriginSciTokensConf
+else
+    ofs.authlib +++ libXrdAccSciTokens.so config=/run/stash-origin-auth/scitokens.conf
 fi

--- a/rpm/xcache.spec
+++ b/rpm/xcache.spec
@@ -1,6 +1,6 @@
 Name:      xcache
 Summary:   XCache scripts and configurations
-Version:   1.5.3
+Version:   1.5.4
 Release:   1%{?dist}
 License:   Apache 2.0
 Group:     Grid
@@ -292,6 +292,10 @@ mkdir -p %{buildroot}%{_sysconfdir}/grid-security/xrd
 %config %{_sysconfdir}/xrootd/config.d/03-redir-tuning.cfg
 
 %changelog
+* Tue Jan 26 2021 Brian Lin <blin@cs.wisc.edu> - 1.5.4-1
+- Update configuration to append SciTokens to the auth list for XRootD
+  5+ (SOFTWARE-4431)
+
 * Wed Jan 13 2021 Brian Lin <blin@cs.wisc.edu> - 1.5.3-1
 - Add default values for the number of blocks and threads used for
   writing in parallel


### PR DESCRIPTION
(SOFTWARE-4431)

We'll need to ship this change alongside an update to XRootD 4's service files to set the `XROOTD4` env var