### PR TITLE
Fix ofs.authlib append syntax (SOFTWARE-4431)

### DIFF
--- a/configs/stash-cache/config.d/50-stash-cache-authz.cfg
+++ b/configs/stash-cache/config.d/50-stash-cache-authz.cfg
@@ -72,9 +72,9 @@ if defined ?StashCacheSciTokensConf && defined ?~XROOTD4
 else if defined ?~XROOTD4
     ofs.authlib libXrdAccSciTokens.so config=/run/stash-cache-auth/scitokens.conf
 else if defined ?StashCacheSciTokensConf
-    ofs.authlib +++ libXrdAccSciTokens.so config=$StashCacheSciTokensConf
+    ofs.authlib ++ libXrdAccSciTokens.so config=$StashCacheSciTokensConf
 else
-    ofs.authlib +++ libXrdAccSciTokens.so config=/run/stash-cache-auth/scitokens.conf
+    ofs.authlib ++ libXrdAccSciTokens.so config=/run/stash-cache-auth/scitokens.conf
 fi
 
 # Pass the bearer token to the Xrootd authorization framework.

--- a/configs/stash-origin/config.d/50-stash-origin-authz.cfg
+++ b/configs/stash-origin/config.d/50-stash-origin-authz.cfg
@@ -68,7 +68,7 @@ if defined ?StashOriginSciTokensConf && defined ?~XROOTD4
 else if defined ?~XROOTD4
     ofs.authlib libXrdAccSciTokens.so config=/run/stash-origin-auth/scitokens.conf
 else if defined ?StashOriginSciTokensConf
-    ofs.authlib +++ libXrdAccSciTokens.so config=$StashOriginSciTokensConf
+    ofs.authlib ++ libXrdAccSciTokens.so config=$StashOriginSciTokensConf
 else
-    ofs.authlib +++ libXrdAccSciTokens.so config=/run/stash-origin-auth/scitokens.conf
+    ofs.authlib ++ libXrdAccSciTokens.so config=/run/stash-origin-auth/scitokens.conf
 fi

--- a/rpm/xcache.spec
+++ b/rpm/xcache.spec
@@ -1,6 +1,6 @@
 Name:      xcache
 Summary:   XCache scripts and configurations
-Version:   1.5.4
+Version:   1.5.5
 Release:   1%{?dist}
 License:   Apache 2.0
 Group:     Grid
@@ -292,6 +292,9 @@ mkdir -p %{buildroot}%{_sysconfdir}/grid-security/xrd
 %config %{_sysconfdir}/xrootd/config.d/03-redir-tuning.cfg
 
 %changelog
+* Wed Jan 27 2021 Brian Lin <blin@cs.wisc.edu> - 1.5.5-1
+- Fix ofs.authlib append syntax (SOFTWARE-4431)
+
 * Tue Jan 26 2021 Brian Lin <blin@cs.wisc.edu> - 1.5.4-1
 - Update configuration to append SciTokens to the auth list for XRootD
   5+ (SOFTWARE-4431)


### PR DESCRIPTION
Per the 5.0/5.1 Open File System config reference manual:

> ofs.authlib [++] path [parms]
>
> Function
> Specify the location of the file system authorization interface layer.
>
> Parameters
>
> ++        The specified plug-in should stack on top of the existing plug-in or default. A stacked plug-in cannot be overridden by a subsequent directive.