### PR TITLE
Add a cmsd-multiuser@ service which pairs with xrootd-privileged@ instead of xrootd@

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,17 +111,20 @@ install:
 	mkdir -p $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/xrootd@stash-cache-auth.service.d
 	install -p -m 0644 configs/stash-cache/overrides/10-stash-cache-overrides.conf $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/xrootd@stash-cache.service.d/
 	install -p -m 0644 configs/stash-cache/overrides/10-stash-cache-auth-overrides.conf $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/xrootd@stash-cache-auth.service.d/
-	ln -s $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/xrootd@stash-cache-auth.service.d $(INSTALL_SYSTEMD_UNITDIR)/xrootd-privileged@stash-cache-auth.service.d
 	# stash-origin
 	mkdir -p $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/xrootd@stash-origin.service.d
 	mkdir -p $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/xrootd@stash-origin-auth.service.d
-	ln -s $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/xrootd@stash-origin-auth.service.d $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/xrootd-privileged@stash-origin-auth.service.d
 	mkdir -p $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/cmsd@stash-origin.service.d
 	mkdir -p $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/cmsd@stash-origin-auth.service.d
+	mkdir -p $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/xrootd-privileged@stash-origin-auth.service.d
+	mkdir -p $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/cmsd-multiuser@stash-origin-auth.service.d
+	install -p -m 0644 configs/stash-origin/systemd/cmsd-multiuser@.service $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/cmsd-multiuser@.service
 	install -p -m 0644 configs/stash-origin/overrides/xrootd/10-stash-origin-overrides.conf $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/xrootd@stash-origin.service.d/
 	install -p -m 0644 configs/stash-origin/overrides/xrootd/10-stash-origin-auth-overrides.conf $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/xrootd@stash-origin-auth.service.d/
+	install -p -m 0644 configs/stash-origin/overrides/xrootd-privileged/10-stash-origin-auth-overrides.conf $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/xrootd-privileged@stash-origin-auth.service.d/
 	install -p -m 0644 configs/stash-origin/overrides/cmsd/10-stash-origin-overrides.conf $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/cmsd@stash-origin.service.d/
 	install -p -m 0644 configs/stash-origin/overrides/cmsd/10-stash-origin-auth-overrides.conf $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/cmsd@stash-origin-auth.service.d/
+	install -p -m 0644 configs/stash-origin/overrides/cmsd-multiuser/10-stash-origin-auth-overrides.conf $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/cmsd-multiuser@stash-origin-auth.service.d/
 	# atlas-xcache
 	mkdir -p $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/xrootd@atlas-xcache.service.d
 	install -p -m 0644 configs/atlas-xcache/overrides/10-atlas-xcache-overrides.conf $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/xrootd@atlas-xcache.service.d/

--- a/configs/stash-origin/overrides/cmsd-multiuser/10-stash-origin-auth-overrides.conf
+++ b/configs/stash-origin/overrides/cmsd-multiuser/10-stash-origin-auth-overrides.conf
@@ -1,0 +1,3 @@
+[Unit]
+Requires=xrootd-privileged@%i.service
+

--- a/configs/stash-origin/overrides/xrootd-privileged/10-stash-origin-auth-overrides.conf
+++ b/configs/stash-origin/overrides/xrootd-privileged/10-stash-origin-auth-overrides.conf
@@ -1,0 +1,14 @@
+[Unit]
+
+# Service dependencies:
+# - Soft dependency on the proxy generation (only used for reporting)
+# - Make sure the authfile is generated before startup, but make it a softer
+#   dependency: we want to allow Xrootd to restart even if the topology service
+#   is down.
+# - Depends on fetch-crl and the reporter script, but doesn't need these
+#   to finish or succeed for startup.
+# - Turn on cmsd; needed to join a federation, but you can shut it off without causing xrootd to turn off also
+Wants=fetch-crl-boot.service fetch-crl-cron.service \
+      stash-origin-authfile.service stash-origin-authfile.timer \
+      cmsd-multiuser@%i.service
+After=stash-origin-authfile.service

--- a/configs/stash-origin/systemd/cmsd-multiuser@.service
+++ b/configs/stash-origin/systemd/cmsd-multiuser@.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=XRootD cmsd daemon instance %I with multiuser
+Documentation=man:cmsd(8)
+Documentation=http://xrootd.org/docs.html
+Requires=network-online.target
+After=network-online.target
+
+[Service]
+ExecStart=/usr/bin/cmsd -l /var/log/xrootd/cmsd.log -c /etc/xrootd/xrootd-%i.cfg -k fifo -s /run/xrootd/cmsd-%i.pid -n %i
+User=xrootd
+Group=xrootd
+Type=simple
+Restart=on-abort
+RestartSec=10
+KillMode=control-group
+LimitNOFILE=65536
+WorkingDirectory=/var/spool/xrootd
+
+[Install]
+RequiredBy=multi-user.target
+

--- a/rpm/xcache.spec
+++ b/rpm/xcache.spec
@@ -233,6 +233,8 @@ mkdir -p %{buildroot}%{_sysconfdir}/grid-security/xrd
 %{_unitdir}/xrootd-privileged@stash-origin-auth.service.d
 %{_unitdir}/cmsd@stash-origin.service.d/10-stash-origin-overrides.conf
 %{_unitdir}/cmsd@stash-origin-auth.service.d/10-stash-origin-auth-overrides.conf
+%{_unitdir}/cmsd-multiuser@.service
+%{_unitdir}/cmsd-multiuser@stash-origin-auth.service.d/10-stash-origin-auth-overrides.conf
 %{_tmpfilesdir}/stash-origin.conf
 %attr(0755, xrootd, xrootd) %dir /run/stash-origin/
 %attr(0755, xrootd, xrootd) %dir /run/stash-origin-auth/
@@ -251,7 +253,6 @@ mkdir -p %{buildroot}%{_sysconfdir}/grid-security/xrd
 %{_unitdir}/stash-cache-authfile.timer
 %{_unitdir}/xrootd@stash-cache.service.d/10-stash-cache-overrides.conf
 %{_unitdir}/xrootd@stash-cache-auth.service.d/10-stash-cache-auth-overrides.conf
-%{_unitdir}/xrootd-privilged@stash-cache-auth.service.d
 %{_tmpfilesdir}/stash-cache.conf
 %attr(0755, xrootd, xrootd) %dir /run/stash-cache/
 %attr(0755, xrootd, xrootd) %dir /run/stash-cache-auth/


### PR DESCRIPTION
This is used for stash-origin-auth (caches don't use multiuser).
https://opensciencegrid.atlassian.net/browse/SOFTWARE-4792