### PR TITLE
Various Python 3 fixups

### DIFF
--- a/configs/xcache-consistency-check/systemd/xcache-consistency-check.service
+++ b/configs/xcache-consistency-check/systemd/xcache-consistency-check.service
@@ -5,7 +5,7 @@ Description=XCache consistency check
 User=xrootd
 Group=xrootd
 Type=simple
-Environment=PYTHONPATH=/usr/lib/xcache-consistency-check/usr/lib/python2.7/site-packages/:/usr/lib/xcache-consistency-check/usr/lib64/python2.7/site-packages/
+Environment=PYTHONPATH=/usr/lib/xcache-consistency-check/usr/lib/python3.6/site-packages/:/usr/lib/xcache-consistency-check/usr/lib64/python3.6/site-packages/
 ExecStart=/usr/bin/xcache-consistency-check --config /etc/xrootd/xcache-consistency-check.cfg
 
 [Install]


### PR DESCRIPTION
- Fix Python 3 bytes/str conversion errors (SOFTWARE-5019)
- Always use Python 3 scripts; update dependencies for xcache-consistency-check
- Fix xrootd_cache_stats.py library location issues (SOFTWARE-5019)
- Fix PYTHONPATH in xcache-consistency-check service file