### PR TITLE
Various Python 3 fixups (V2-branch)

### DIFF
--- a/configs/xcache-consistency-check/systemd/xcache-consistency-check.service
+++ b/configs/xcache-consistency-check/systemd/xcache-consistency-check.service
@@ -5,7 +5,7 @@ Description=XCache consistency check
 User=xrootd
 Group=xrootd
 Type=simple
-Environment=PYTHONPATH=/usr/lib/xcache-consistency-check/usr/lib/python2.7/site-packages/:/usr/lib/xcache-consistency-check/usr/lib64/python2.7/site-packages/
+Environment=PYTHONPATH=/usr/lib/xcache-consistency-check/usr/lib/python3.6/site-packages/:/usr/lib/xcache-consistency-check/usr/lib64/python3.6/site-packages/
 ExecStart=/usr/bin/xcache-consistency-check --config /etc/xrootd/xcache-consistency-check.cfg
 
 [Install]

--- a/rpm/xcache.spec
+++ b/rpm/xcache.spec
@@ -1,23 +1,25 @@
 Name:      xcache
 Summary:   XCache scripts and configurations
-Version:   2.1.0
+Version:   2.1.1
 Release:   1%{?dist}
 License:   Apache 2.0
 Group:     Grid
 URL:       https://opensciencegrid.org/docs/
 Source0:   %{name}-%{version}.tar.gz
-Source1:   https://vdt.cs.wisc.edu/upstream/xcache/1.3.0/python-deps/numpy-1.16.6-cp27-cp27mu-manylinux1_x86_64.whl
-Source2:   https://vdt.cs.wisc.edu/upstream/xcache/1.3.0/python-deps/cachetools-3.1.1-py2.py3-none-any.whl
-Source3:   https://vdt.cs.wisc.edu/upstream/xcache/1.3.0/python-deps/awkward-0.12.20-py2.py3-none-any.whl
-Source4:   https://vdt.cs.wisc.edu/upstream/xcache/1.3.0/python-deps/uproot_methods-0.7.3-py2.py3-none-any.whl
-Source5:   https://vdt.cs.wisc.edu/upstream/xcache/1.3.0/python-deps/uproot-3.11.2-py2.py3-none-any.whl
-Source6:   https://vdt.cs.wisc.edu/upstream/xcache/1.3.0/python-deps/xxhash-1.4.3-cp27-cp27mu-manylinux1_x86_64.whl
-Source7:   https://vdt.cs.wisc.edu/upstream/xcache/1.3.0/python-deps/lz4-2.2.1-cp27-cp27mu-manylinux1_x86_64.whl
-Source8:   https://vdt.cs.wisc.edu/upstream/xcache/1.3.0/python-deps/pyliblzma-0.5.3.tar.bz2
+Source1:   https://vdt.cs.wisc.edu/upstream/xcache/3.0.0/python-deps/numpy-1.16.6-cp36-cp36m-manylinux1_x86_64.whl
+Source2:   https://vdt.cs.wisc.edu/upstream/xcache/3.0.0/python-deps/cachetools-3.1.1-py2.py3-none-any.whl
+Source3:   https://vdt.cs.wisc.edu/upstream/xcache/3.0.0/python-deps/awkward-0.12.22-py2.py3-none-any.whl
+Source4:   https://vdt.cs.wisc.edu/upstream/xcache/3.0.0/python-deps/uproot_methods-0.7.4-py2.py3-none-any.whl
+Source5:   https://vdt.cs.wisc.edu/upstream/xcache/3.0.0/python-deps/uproot-3.11.7-py2.py3-none-any.whl
+Source6:   https://vdt.cs.wisc.edu/upstream/xcache/3.0.0/python-deps/xxhash-1.4.4-cp36-cp36m-manylinux1_x86_64.whl
+Source7:   https://vdt.cs.wisc.edu/upstream/xcache/3.0.0/python-deps/lz4-2.2.1-cp36-cp36m-manylinux1_x86_64.whl
 
 
 BuildRequires: systemd
 %{?systemd_requires}
+
+%define __python /usr/bin/python3
+BuildRequires: python3-devel
 
 # Necessary for daemon to report back to the OSG Collector.
 Requires: python3-condor
@@ -39,10 +41,6 @@ Requires: xrootd-scitokens
 Provides: stashcache-daemon = %{name}-%{version}
 Obsoletes: stashcache-daemon < 1.0.0
 
-%if 0%{?rhel} >= 8
-%define __python /usr/bin/python3
-%endif
-
 %description
 %{summary}
 
@@ -56,15 +54,13 @@ Obsoletes: stashcache-daemon < 1.0.0
 
 ########################################
 %package -n xcache-consistency-check
-BuildRequires: python2-pip
-BuildRequires: python2-devel
-BuildRequires: xz-devel
 Summary: Consistency check for root files
 AutoReq: no
 %global __provides_exclude ^libgfortran.*\\.so.*$|^libopenblasp.*\\.so.*$
 
 Requires: xz
 Requires: xrootd-server
+Requires: python3
 
 %description -n xcache-consistency-check
 %{summary}
@@ -179,15 +175,13 @@ Requires: %{name} = %{version}
 %setup -n %{name}-%{version} -q
 
 %install
-%if 0%{?rhel} >= 8
-find . -type f -exec sed -ri '1s,^#!\s*(/usr)?/bin/(env )?python.*,#!%{__python},' '{}' +
-%endif
+#find . -type f -exec sed -ri '1s,^#!\s*(/usr)?/bin/(env )?python.*,#!%{__python},' '{}' +
 
 mkdir -p %{buildroot}%{_sysconfdir}/xrootd
 mkdir -p %{buildroot}/usr/lib/xcache-consistency-check
-for whl in %{SOURCE1} %{SOURCE2} %{SOURCE3} %{SOURCE4} %{SOURCE5} %{SOURCE6} %{SOURCE7} %{SOURCE8} 
+for whl in %{SOURCE1} %{SOURCE2} %{SOURCE3} %{SOURCE4} %{SOURCE5} %{SOURCE6} %{SOURCE7}
 do
-    pip2 install -I --no-deps "$whl" --root %{buildroot}/usr/lib/xcache-consistency-check
+    %{__python} -m pip install -I --no-deps "$whl" --root %{buildroot}/usr/lib/xcache-consistency-check
 done
 
 make install DESTDIR=%{buildroot} PYTHON=%{__python}
@@ -198,7 +192,8 @@ mkdir -p %{buildroot}%{_sysconfdir}/grid-security/xrd
 %files
 %{_libexecdir}/%{name}/xcache-reporter
 %{_libexecdir}/%{name}/renew-proxy
-%{python_sitelib}/xrootd_cache_stats.py*
+%{python3_sitelib}/xrootd_cache_stats.py*
+%{python3_sitelib}/__pycache__/xrootd_cache_stats.*
 %{_unitdir}/xcache-reporter.service
 %{_unitdir}/xcache-reporter.timer
 %{_unitdir}/xrootd-renew-proxy.service
@@ -285,6 +280,12 @@ mkdir -p %{buildroot}%{_sysconfdir}/grid-security/xrd
 %config %{_sysconfdir}/xrootd/config.d/03-redir-tuning.cfg
 
 %changelog
+* Thu Mar 24 2022 Mátyás Selmeci <matyas@cs.wisc.edu> - 2.1.1-1
+- Fix PYTHONPATH in xcache-consistency-check service file
+- Fix Python 3 bytes/str conversion errors (SOFTWARE-5019)
+- Always use Python 3 scripts; update dependencies for xcache-consistency-check
+- Fix xrootd_cache_stats.py library location issues (SOFTWARE-5019)
+
 * Wed Oct 27 2021 Mátyás Selmeci <matyas@cs.wisc.edu> - 2.1.0-1
 - Add overrides for xrootd-privileged@stash-origin-auth, and add
   cmsd-multiuser@.service for running an auth stash-origin with multiuser (SOFTWARE-4792)
@@ -321,7 +322,7 @@ mkdir -p %{buildroot}%{_sysconfdir}/grid-security/xrd
 * Tue Nov 10 2020 Mátyás Selmeci <matyas@cs.wisc.edu> - 1.5.2-2
 - Include xrootd-client in stash-origin since it's used for validation (SOFTWARE-4353)
 
-* Fri Jul 30 2020 Edgar Fajardo <emfajard@ucsd.edu> - 1.5.2-1
+* Fri Jul 31 2020 Edgar Fajardo <emfajard@ucsd.edu> - 1.5.2-1
 - Fixing some bugs for el8 suppport (SOFTWARE-4158)
 
 * Mon Jul 27 2020 Edgar Fajardo <emfajard@ucsd.edu> - 1.5.0-1


### PR DESCRIPTION
- Always use Python 3 scripts; update dependencies for xcache-consistency-check
- Fix xrootd_cache_stats.py library location issues (SOFTWARE-5019)
- Fix PYTHONPATH in xcache-consistency-check service file

Same as #125