### PR TITLE
drop GSI auth method (SOFTWARE-5121)

### DIFF
--- a/configs/xcache/condor/01-xcache-reporter-auth.conf
+++ b/configs/xcache/condor/01-xcache-reporter-auth.conf
@@ -1,5 +1,5 @@
 # Advertise to the central collector with SSL (SOFTWARE-3940)
-SEC_CLIENT_AUTHENTICATION_METHODS = SSL, GSI
+SEC_CLIENT_AUTHENTICATION_METHODS = SSL
 
 AUTH_SSL_CLIENT_CERTFILE = /etc/grid-security/xrd/xrdcert.pem
 AUTH_SSL_CLIENT_KEYFILE=/etc/grid-security/xrd/xrdkey.pem


### PR DESCRIPTION
Per SOFTWARE-5121, GSI being enabled here causes an annoying warning in xcache-reporter, and it wouldn’t work anyway because GSI is not compiled in to HTCondor.