### PR TITLE
Split stash-origin's "originexport" var into "PublicOriginExport" and "AuthOriginExport"

### DIFF
--- a/configs/stash-origin/config.d/10-origin-site-local.cfg
+++ b/configs/stash-origin/config.d/10-origin-site-local.cfg
@@ -9,13 +9,28 @@
 # This file is part of the StashCache Daemon
 # https://opensciencegrid.org/docs/data/stashcache/overview/
 
-# You MUST uncomment and fill ALL variables below.
-# They have been purposely commented out to cause the server to
-# fail to start unless you edit them.
+# You MUST uncomment and fill at least one of the OriginExport
+# variables below.  They have been purposely commented out to
+# cause the server to fail to start unless you edit them.
 
-# A directory *relative to rootdir* that is the top of the
-# exported namespace.  If files are stored locally in `/mnt/stash/VO`,
-# `rootdir` is set to `/mnt/stash`, and `originexport` is `/VO`,
-# then clients can access the files within the namespace `/VO`.
+# The OriginExport variables are *relative to rootdir* and are
+# at the top of the exported namespace.
 #
-# set originexport = /VO
+# For example, if files are stored locally in `/mnt/stash/VO/PUBLIC`,
+# `rootdir` is set to `/mnt/stash`, and `PublicOriginExport` is
+# `/VO/PUBLIC`, then clients can access the files within the
+# namespace `/VO/PUBLIC`.
+
+# PublicOriginExport is the namespace exported by public
+# (unauthenticated) origins (the "stash-origin" xrootd instance).
+# You may leave it commented if you are only running an authenticated
+# origin.
+#
+# set PublicOriginExport = /VO/PUBLIC
+
+# AuthOriginExport is the namespace exported by authenticated
+# origins (the "stash-origin-auth" xrootd instance).
+# You may leave it commented if you are only running an unauthenticated
+# origin.
+#
+# set AuthOriginExport = /VO/PROTECTED

--- a/configs/stash-origin/config.d/50-stash-origin-paths.cfg
+++ b/configs/stash-origin/config.d/50-stash-origin-paths.cfg
@@ -15,13 +15,13 @@
 # NOTE: the StashCache namespace is global; do not share paths that may
 # collide with paths provided by other origin servers.
 
-if defined $(PublicOriginExport) && named stash-origin
+if defined ?PublicOriginExport && named stash-origin
   all.export $(PublicOriginExport)
 
-else if defined $(AuthOriginExport) && named stash-origin-auth
+else if defined ?AuthOriginExport && named stash-origin-auth
   all.export $(AuthOriginExport)
 
-else if defined $(originexport)
+else if defined ?originexport
   ### backward compat
   all.export $(originexport)
 fi

--- a/configs/stash-origin/config.d/50-stash-origin-paths.cfg
+++ b/configs/stash-origin/config.d/50-stash-origin-paths.cfg
@@ -14,5 +14,15 @@
 #
 # NOTE: the StashCache namespace is global; do not share paths that may
 # collide with paths provided by other origin servers.
-all.export $(originexport)
+
+if defined $(PublicOriginExport) && named stash-origin
+  all.export $(PublicOriginExport)
+
+else if defined $(AuthOriginExport) && named stash-origin-auth
+  all.export $(AuthOriginExport)
+
+else if defined $(originexport)
+  ### backward compat
+  all.export $(originexport)
+fi
 


### PR DESCRIPTION
PublicOriginExport is used on the stash-origin xrootd/cmsd instances, and AuthOriginExport is used on the stash-origin-auth xrootd/cmsd instances. originexport is kept for backward compat.

([SOFTWARE-5303](https://opensciencegrid.atlassian.net/browse/SOFTWARE-5303))