### PR TITLE
Fix systemd packaging for cmsd-privileged (SOFTWARE-5338)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,13 +118,14 @@ install:
 	mkdir -p $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/cmsd@stash-origin-auth.service.d
 	mkdir -p $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/xrootd-privileged@stash-origin-auth.service.d
 	mkdir -p $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/cmsd-multiuser@stash-origin-auth.service.d
+	mkdir -p $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/cmsd-privileged@stash-origin-auth.service.d
 	install -p -m 0644 configs/stash-origin/systemd/cmsd-multiuser@.service $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/cmsd-multiuser@.service
 	install -p -m 0644 configs/stash-origin/overrides/xrootd/10-stash-origin-overrides.conf $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/xrootd@stash-origin.service.d/
 	install -p -m 0644 configs/stash-origin/overrides/xrootd/10-stash-origin-auth-overrides.conf $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/xrootd@stash-origin-auth.service.d/
 	install -p -m 0644 configs/stash-origin/overrides/xrootd-privileged/10-stash-origin-auth-overrides.conf $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/xrootd-privileged@stash-origin-auth.service.d/
 	install -p -m 0644 configs/stash-origin/overrides/cmsd/10-stash-origin-overrides.conf $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/cmsd@stash-origin.service.d/
 	install -p -m 0644 configs/stash-origin/overrides/cmsd/10-stash-origin-auth-overrides.conf $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/cmsd@stash-origin-auth.service.d/
-	install -p -m 0644 configs/stash-origin/overrides/cmsd-multiuser/10-stash-origin-auth-overrides.conf $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/cmsd-multiuser@stash-origin-auth.service.d/
+	install -p -m 0644 configs/stash-origin/overrides/cmsd-privileged/10-stash-origin-auth-overrides.conf $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/cmsd-privileged@stash-origin-auth.service.d/
 	# atlas-xcache
 	mkdir -p $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/xrootd@atlas-xcache.service.d
 	install -p -m 0644 configs/atlas-xcache/overrides/10-atlas-xcache-overrides.conf $(DESTDIR)/$(INSTALL_SYSTEMD_UNITDIR)/xrootd@atlas-xcache.service.d/

--- a/rpm/xcache.spec
+++ b/rpm/xcache.spec
@@ -228,7 +228,7 @@ mkdir -p %{buildroot}%{_sysconfdir}/grid-security/xrd
 %{_unitdir}/cmsd@stash-origin.service.d/10-stash-origin-overrides.conf
 %{_unitdir}/cmsd@stash-origin-auth.service.d/10-stash-origin-auth-overrides.conf
 %{_unitdir}/cmsd-multiuser@.service
-%{_unitdir}/cmsd-multiuser@stash-origin-auth.service.d/10-stash-origin-auth-overrides.conf
+%{_unitdir}/cmsd-privileged@stash-origin-auth.service.d/10-stash-origin-auth-overrides.conf
 %{_tmpfilesdir}/stash-origin.conf
 %attr(0755, xrootd, xrootd) %dir /run/stash-origin/
 %attr(0755, xrootd, xrootd) %dir /run/stash-origin-auth/


### PR DESCRIPTION
... and update Makefile, which is almost packaging.

It took several wrong attempts to get this to build; the main point here seems to be to keep the cmsd-multiuser *service* and the cmsd-privileged *override*, and *not* the other way around.