### PR TITLE
Rewrite authfile-update in Python; add better paths for .local files (SOFTWARE-5597)

### DIFF
--- a/src/authfile-update
+++ b/src/authfile-update
@@ -11,7 +11,7 @@ import urllib.error
 import urllib.request
 
 
-INSTANCES = [
+KNOWN_INSTANCES = [
     "stash-origin",
     "stash-origin-auth",
     "stash-cache",
@@ -56,12 +56,17 @@ def die_with_usage(prog):
     print(
         f"""
 Usage: {prog} <instance>
+   or  {prog} --cache
+   or  {prog} --origin
 
 where <instance> is one of:
     stash-cache
     stash-cache-auth
     stash-origin
     stash-origin-auth
+
+--cache is equivalent to running it for stash-cache and stash-cache-auth
+--origin is equivalent to running it for stash-origin and stash-origin-auth
 
 Environment variables used:
     CACHE_FQDN      FQDN used for cache authfile query (default: the full hostname)
@@ -170,24 +175,15 @@ class Download:
         print(f"{lines} lines written successfully to {self.dest_file}.")
 
 
-def main(argv):
-    topology = os.environ.get("TOPOLOGY", "https://topology.opensciencegrid.org")
-    destdir = os.environ.get("DESTDIR", "/run")
-    ret = 0
-
-    if len(argv) != 2:
-        die_with_usage(argv[0])
-
-    instance = argv[1]
-    if instance not in INSTANCES:
-        complain(f"Unknown instance {instance}")
-        die_with_usage(argv[0])
+def handle_instance(instance, topology, destdir):
     if "cache" in instance:
         fqdn = os.environ.get("CACHE_FQDN", socket.getfqdn())
     elif "origin" in instance:
         fqdn = os.environ.get("ORIGIN_FQDN", socket.getfqdn())
     else:
         assert False, f"bad instance {instance} should have been caught"
+
+    ret = 0
 
     for config_file in CONFIG_FILES:
         dl = Download(
@@ -228,5 +224,33 @@ def main(argv):
     return ret
 
 
+def main(argv=None):
+    if argv is None:
+        argv = sys.argv
+
+    topology = os.environ.get("TOPOLOGY", "https://topology.opensciencegrid.org")
+    destdir = os.environ.get("DESTDIR", "/run")
+    ret = 0
+
+    if len(argv) != 2:
+        die_with_usage(argv[0])
+
+    if argv[1] == "--cache":
+        instances = ["stash-cache", "stash-cache-auth"]
+    elif argv[1] == "--origin":
+        instances = ["stash-origin", "stash-origin-auth"]
+    else:
+        if argv[1] not in KNOWN_INSTANCES:
+            complain(f"Unknown instance {argv[1]}")
+            die_with_usage(argv[0])
+        else:
+            instances = [argv[1]]
+
+    for instance in instances:
+        ret |= handle_instance(instance, topology=topology, destdir=destdir)
+
+    return ret
+
+
 if __name__ == "__main__":
-    sys.exit(main(sys.argv))
+    sys.exit(main())

--- a/src/authfile-update
+++ b/src/authfile-update
@@ -135,7 +135,7 @@ class Download:
                 with open(local_file, "rt", encoding="utf-8", errors="replace") as fh:
                     new_text += (
                         f"## The following lines are from {local_file}:\n"
-                        + fh.read()
+                        + fh.read().rstrip("\n")
                         + "\n\n"
                     )
             except FileNotFoundError:
@@ -145,10 +145,10 @@ class Download:
 
         if new_text:
             if self.prepend_local:
-                new_text += "\n## The following lines are from OSG Topology:\n" + text
+                new_text += "## The following lines are from OSG Topology:\n" + text
             else:
-                new_text = text + "\n\n" + new_text + "\n"
-            return new_text
+                new_text = text + "\n\n" + new_text
+            return new_text.rstrip("\n") + "\n"  # have exactly one final newline
         else:
             return text
 

--- a/src/authfile-update
+++ b/src/authfile-update
@@ -1,153 +1,232 @@
-#!/bin/bash
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+import os
+import shutil
+import socket
+import subprocess
+import sys
+from typing import Optional, Tuple
+import urllib
+import urllib.error
+import urllib.request
 
-fetch () {
-    local src=$1 dst=$2
-    local tmp=$2.tmp
-    local ret
 
-    if [[ ! -d $(dirname "$dst") ]]; then
-        echo >&2 "Destination directory does not exist"
-        return 1
-    fi
-    rm -f "$tmp"
-    wget "$src" -q --content-on-error -O "$tmp"; ret=$?
-    if [[ $ret != 0 ]]; then
-        echo >&2 "Error fetching $src"
-        if [[ -s $tmp ]]; then
-            echo >&2 "File contents:"
-            cat >&2 "$tmp"
-        fi
-        return 1
-    else
-        mv -f "$tmp" "$dst"
-    fi
+INSTANCES = [
+    "stash-origin",
+    "stash-origin-auth",
+    "stash-cache",
+    "stash-cache-auth",
+]
+
+
+# fmt: off
+ENDPOINTS = {
+    "Authfile": {
+        "stash-origin"      : "/origin/Authfile-public?fqdn={fqdn}",
+        "stash-origin-auth" : "/origin/Authfile?fqdn={fqdn}",
+        "stash-cache"       : "/cache/Authfile-public?fqdn={fqdn}",
+        "stash-cache-auth"  : "/cache/Authfile?fqdn={fqdn}",
+    },
+    "scitokens.conf": {
+        "stash-origin"      : None,
+        "stash-origin-auth" : "/origin/scitokens.conf?fqdn={fqdn}",
+        "stash-cache"       : None,
+        "stash-cache-auth"  : "/cache/scitokens.conf?fqdn={fqdn}",
+    },
+    "grid-mapfile": {
+        "stash-origin"      : None,
+        "stash-origin-auth" : "/origin/grid-mapfile?fqdn={fqdn}",
+        "stash-cache"       : None,
+        "stash-cache-auth"  : "/cache/grid-mapfile?fqdn={fqdn}",
+    },
 }
-
-die_with_usage () {
-    echo >&2 "Usage: $(basename "$0") --cache|--origin"
-    echo >&2 "   Or: $(basename "$0") stash-cache|stash-cache-auth|stash-origin|stash-origin-auth"
-    echo >&2 "Environment variables used:"
-    echo >&2 "CACHE_FQDN        FQDN used for cache authfile query (default `hostname -f`)"
-    echo >&2 "ORIGIN_FQDN       FQDN used for origin authfile query (default `hostname -f`)"
-    echo >&2 "TOPOLOGY          Topology server to get the data from (default https://topology.opensciencegrid.org)"
-    exit 2
-}
-
-if [[ $# -ne 1 ]]; then
-    die_with_usage
-fi
-
-TOPOLOGY=${TOPOLOGY:-https://topology.opensciencegrid.org}
-CACHE_FQDN=${CACHE_FQDN:-$(hostname -f)}
-ORIGIN_FQDN=${ORIGIN_FQDN:-$(hostname -f)}
-
-DESTDIR=${DESTDIR:-/run}
+# fmt: on
 
 
-prepend_local_additions () {
-    local base="$1"
-    local tmp="${base}.$$"
-    local ret=0
-    if [[ -s $base && -f ${base}.local ]]; then
-        echo -e "\n# The following lines are from $(basename "${base}.local"):" > "$tmp"  && \
-            cat "${base}.local" >> "$tmp"  && \
-            echo -e "\n# The following lines are from OSG Topology:" >> "$tmp"  && \
-            cat "${base}" >> "$tmp"  && \
-            mv -f "$tmp" "$base"
-        ret=$?
-    fi
-    rm -f "$tmp"
-    return $ret
-}
+CONFIG_FILES = list(ENDPOINTS.keys())
 
 
-append_local_additions () {
-    local base="$1"
-    if [[ -s $base && -f ${base}.local ]]; then
-        echo -e "\n# The following lines are from $(basename "${base}.local"):" >> "$base"
-        cat "${base}.local" >> "$base"
-    fi
-}
+def complain(*values, **kwargs):
+    # print to sys.stderr
+    kwargs["file"] = sys.stderr
+    return print(*values, **kwargs)
 
 
-fetch_cache_data () {
-    mkdir -p "$DESTDIR/stash-cache"
-    fetch "${TOPOLOGY}/cache/Authfile-public?fqdn=${CACHE_FQDN}" "$DESTDIR/stash-cache/Authfile" && \
-        append_local_additions "$DESTDIR/stash-cache/Authfile"
-}
+def die_with_usage(prog):
+    print(
+        f"""
+Usage: {prog} <instance>
+
+where <instance> is one of:
+    stash-cache
+    stash-cache-auth
+    stash-origin
+    stash-origin-auth
+
+Environment variables used:
+    CACHE_FQDN      FQDN used for cache authfile query (default: the full hostname)
+    ORIGIN_FQDN     FQDN used for origin authfile query (default: the full hostname)
+    TOPOLOGY        Topology server to get the data from (default: https://topology.opensciencegrid.org)
+    DESTDIR         The base directory to write results to (default: /run)
+""",
+        file=sys.stderr,
+    )
+    sys.exit(2)
 
 
-fetch_cache_auth_data () {
-    mkdir -p "$DESTDIR/stash-cache-auth"
-    local ret=0
-    fetch "${TOPOLOGY}/cache/Authfile?fqdn=${CACHE_FQDN}" "$DESTDIR/stash-cache-auth/Authfile" && \
-        append_local_additions "$DESTDIR/stash-cache-auth/Authfile"
-    ret=$(( $ret | $? ))
-    fetch "${TOPOLOGY}/cache/scitokens.conf?fqdn=${CACHE_FQDN}" "$DESTDIR/stash-cache-auth/scitokens.conf" && \
-        append_local_additions "$DESTDIR/stash-cache-auth/scitokens.conf"
-    ret=$(( $ret | $? ))
-    fetch "${TOPOLOGY}/cache/grid-mapfile?fqdn=${CACHE_FQDN}" "$DESTDIR/stash-cache-auth/grid-mapfile" && \
-        prepend_local_additions "$DESTDIR/stash-cache-auth/grid-mapfile"
-    ret=$(( $ret | $? ))
-    return $ret
-}
+class Download:
+    def __init__(self, topology, destdir, instance, config_file, fqdn):
+        self.topology = topology
+        self.destdir = destdir
+        self.instance = instance
+        self.config_file = config_file
+        self.fqdn = fqdn
+
+        self.full_destdir = f"{self.destdir}/{self.instance}"
+        self.dest_file = f"{self.full_destdir}/{self.config_file}"
+        self.local_files = [
+            f"{self.destdir}/{self.instance}/{self.config_file}.local",
+            f"/etc/xrootd/{self.instance}-{self.config_file}.local",
+        ]
+        self.prepend_local = config_file == "grid-mapfile"
+        # ^^ local additions to the grid-mapfile are prepended, not appended
+        #    to what's downloaded from topology
+
+    def fetch(self) -> Tuple[Optional[str], bool]:
+        """Download the data for this config file from Topology and return
+        the content of the download (`text`) and a boolean indicating
+        success/failure (based on HTTP return code) (`ok`).
+
+        Returns (None, True) if there is no endpoint for this config file e.g.
+        scitokens.conf for an unauthenticated cache.
+
+        """
+        endpoint = ENDPOINTS[self.config_file][self.instance]
+        if not endpoint:
+            return None, True
+
+        url = self.topology + endpoint.format(fqdn=self.fqdn)
+        try:
+            response = urllib.request.urlopen(url)
+            text = response.read()
+            if text:
+                ok = True
+            else:
+                ok = False
+        except urllib.error.HTTPError as err:
+            # An HTTP error might indicate an error with the Topology registration
+            # or the query; the contents are useful.
+            text = err.read()
+            ok = False
+        if not isinstance(text, str):
+            text = text.decode("utf-8", errors="replace")
+
+        return text, ok
+
+    def combine_with_local_files(self, text: str) -> str:
+        """Return the given text with the additions from the local files
+        for this config file, if there are any.  Missing files are silently
+        skipped; other read errors are reported but are not failures.
+
+        """
+        new_text = ""
+        for local_file in self.local_files:
+            try:
+                with open(local_file, "rt", encoding="utf-8", errors="replace") as fh:
+                    new_text += (
+                        f"## The following lines are from {local_file}:\n"
+                        + fh.read()
+                        + "\n\n"
+                    )
+            except FileNotFoundError:
+                pass
+            except OSError as err:
+                complain(f"Couldn't read local file {local_file}: {err} (continuing)")
+
+        if new_text:
+            if self.prepend_local:
+                new_text += "\n## The following lines are from OSG Topology:\n" + text
+            else:
+                new_text = text + "\n\n" + new_text + "\n"
+            return new_text
+        else:
+            return text
+
+    def report_download_error(self, text):
+        """Print errors downloading the config file for the instance."""
+        complain(f"Error fetching {self.config_file} for {self.instance}")
+        if not text:
+            complain("No data received")
+            return
+        complain("Response follows:")
+        complain(text)
+
+    def write_dest_file(self, text):
+        """Writes the destination file atomically."""
+        with open(self.dest_file + ".new", "wt", encoding="utf-8") as new_fh:
+            new_fh.write(text)
+        shutil.move(self.dest_file + ".new", self.dest_file)
+        lines = text.count("\n")
+        print(f"{lines} lines written successfully to {self.dest_file}.")
 
 
-fetch_origin_data () {
-    mkdir -p "$DESTDIR/stash-origin"
-    fetch "${TOPOLOGY}/origin/Authfile-public?fqdn=${ORIGIN_FQDN}" "$DESTDIR/stash-origin/Authfile" && \
-        append_local_additions "$DESTDIR/stash-origin/Authfile"
-}
+def main(argv):
+    topology = os.environ.get("TOPOLOGY", "https://topology.opensciencegrid.org")
+    destdir = os.environ.get("DESTDIR", "/run")
+    ret = 0
+
+    if len(argv) != 2:
+        die_with_usage(argv[0])
+
+    instance = argv[1]
+    if instance not in INSTANCES:
+        complain(f"Unknown instance {instance}")
+        die_with_usage(argv[0])
+    if "cache" in instance:
+        fqdn = os.environ.get("CACHE_FQDN", socket.getfqdn())
+    elif "origin" in instance:
+        fqdn = os.environ.get("ORIGIN_FQDN", socket.getfqdn())
+    else:
+        assert False, f"bad instance {instance} should have been caught"
+
+    for config_file in CONFIG_FILES:
+        dl = Download(
+            topology=topology,
+            destdir=destdir,
+            instance=instance,
+            config_file=config_file,
+            fqdn=fqdn,
+        )
+
+        if not os.path.isdir(dl.full_destdir):
+            complain(f"Destination directory {dl.full_destdir} doesn't exist")
+            return 1  # none of the other downloads will work either
+
+        text, ok = dl.fetch()
+
+        if not ok:
+            # some failure happened; inform user of the error but then continue with
+            # the next file
+            ret = 1
+            dl.report_download_error(text)
+            continue
+
+        if not text:
+            # we didn't download test but that may be ok for this instance
+            continue
+
+        # download is successful; now combine the file with any local files
+        text = dl.combine_with_local_files(text)
+
+        try:
+            dl.write_dest_file(text)
+        except OSError as err:
+            complain(f"Couldn't write {dl.dest_file}: {err}")
+            ret = 1
+            continue
+
+    return ret
 
 
-fetch_origin_auth_data () {
-    mkdir -p "$DESTDIR/stash-origin-auth"
-    local ret=0
-    fetch "${TOPOLOGY}/origin/Authfile?fqdn=${ORIGIN_FQDN}" "$DESTDIR/stash-origin-auth/Authfile" && \
-        append_local_additions "$DESTDIR/stash-origin-auth/Authfile"
-    ret=$(( $ret | $? ))
-    fetch "${TOPOLOGY}/origin/scitokens.conf?fqdn=${ORIGIN_FQDN}" "$DESTDIR/stash-origin-auth/scitokens.conf" && \
-        append_local_additions "$DESTDIR/stash-origin-auth/scitokens.conf"
-    ret=$(( $ret | $? ))
-    fetch "${TOPOLOGY}/origin/grid-mapfile?fqdn=${ORIGIN_FQDN}" "$DESTDIR/stash-origin-auth/grid-mapfile" && \
-        prepend_local_additions "$DESTDIR/stash-origin-auth/grid-mapfile"
-    ret=$(( $ret | $? ))
-    return $ret
-}
-
-
-case $1 in
-    --cache)
-        ret=0
-        fetch_cache_data
-        ret=$(( $ret | $? ))
-        fetch_cache_auth_data
-        ret=$(( $ret | $? ))
-        ;;
-    --origin)
-        ret=0
-        fetch_origin_data
-        ret=$(( $ret | $? ))
-        fetch_origin_auth_data
-        ret=$(( $ret | $? ))
-        ;;
-    stash-cache)
-        fetch_cache_data
-        ret=$?
-        ;;
-    stash-cache-auth)
-        fetch_cache_auth_data
-        ret=$?
-        ;;
-    stash-origin)
-        fetch_origin_data
-        ret=$?
-        ;;
-    stash-origin-auth)
-        fetch_origin_auth_data
-        ret=$?
-        ;;
-    *)
-        die_with_usage
-esac
-exit $ret
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
Take local additions to generated Authfile, scitokens.conf, and
grid-mapfile files from paths under /etc/xrootd.  The new paths
have the pattern `/etc/xrootd/$INSTANCE-$FILE.local` for example
`/etc/xrootd/stash-cache-auth-Authfile.local`

The old paths under /run are still supported for backward compatibility.
The combined files have comments indicating which file each block
came from.

The script was getting hairy enough that I decided to rewrite it in
Python.