### PR TITLE
Fix EL9 python dependency

### DIFF
--- a/rpm/xcache.spec
+++ b/rpm/xcache.spec
@@ -1,7 +1,7 @@
 Name:      xcache
 Summary:   XCache scripts and configurations
 Version:   3.5.0
-Release:   2%{?dist}
+Release:   4%{?dist}
 License:   Apache 2.0
 Group:     Grid
 URL:       https://opensciencegrid.org/docs/
@@ -76,7 +76,7 @@ AutoReq: no
 Requires: xz
 Requires: xrootd-server
 %if 0%{?el9}
-Requires: python39(x86-64)
+Requires: python3.9(x86-64)
 %else
 Requires: python36(x86-64)
 %endif
@@ -306,6 +306,9 @@ mkdir -p %{buildroot}%{_sysconfdir}/grid-security/xrd
 %config %{_sysconfdir}/xrootd/config.d/03-redir-tuning.cfg
 
 %changelog
+* Thu Sep 28 2023 Brian Lin <blin@cs.wisc.edu> - 3.5.0-4
+- Fix EL9 python dependency
+
 * Fri Jun 23 2023 Mátyás Selmeci <matyas@cs.wisc.edu> - 3.5.0-2
 - Add xrdcl-http dependency for stash-cache (SOFTWARE-5606)
 


### PR DESCRIPTION
Also bump the release version twice since we have a 3.5.0-3 in OSG 23
already: https://github.com/opensciencegrid/xcache/releases/tag/v3.5.0-3

```
blin@blin-work:~$ podman run --rm -it quay.io/rockylinux/rockylinux:9 rpm -q --provides python3
platform-python = 3.9.16-1.el9
platform-python(x86-64) = 3.9.16-1.el9
python(abi) = 3.9
python(abi) = 3.9
python3 = 3.9.16-1.el9
python3(x86-64) = 3.9.16-1.el9
python3.9 = 3.9.16-1.el9
python3.9(x86-64) = 3.9.16-1.el9
python39 = 3.9.16-1.el9
blin@blin-work:~$ podman run --rm -it quay.io/almalinux/almalinux:9 rpm -q --provides python3
platform-python = 3.9.14-1.el9_1.1
platform-python(x86-64) = 3.9.14-1.el9_1.1
python(abi) = 3.9
python(abi) = 3.9
python3 = 3.9.14-1.el9_1.1
python3(x86-64) = 3.9.14-1.el9_1.1
python3.9 = 3.9.14-1.el9_1.1
python3.9(x86-64) = 3.9.14-1.el9_1.1
python39 = 3.9.14-1.el9_1.1
blin@blin-work:~$ podman run --rm -it quay.io/centos/centos:stream9 rpm -q --provides python3
platform-python = 3.9.16-1.el9
platform-python(x86-64) = 3.9.16-1.el9
python(abi) = 3.9
python(abi) = 3.9
python3 = 3.9.16-1.el9
python3(x86-64) = 3.9.16-1.el9
python3.9 = 3.9.16-1.el9
python3.9(x86-64) = 3.9.16-1.el9
python39 = 3.9.16-1.el9
```