### PR TITLE
Use grid-mapfile downloaded from Topology

### DIFF
--- a/configs/xcache/config.d/40-xcache-auth.cfg
+++ b/configs/xcache/config.d/40-xcache-auth.cfg
@@ -14,3 +14,25 @@ if named stash-cache
 else
     setenv X509_USER_PROXY = /run/xcache-auth/x509_proxy
 fi
+
+
+if defined ?GridMapfile
+    # pass
+else if named stash-cache-auth
+    set GridMapfile = /run/stash-cache-auth/grid-mapfile
+else if named stash-origin-auth
+    set GridMapfile = /run/stash-origin-auth/grid-mapfile
+else
+    set GridMapfile = /etc/grid-security/grid-mapfile
+fi
+
+if defined ?GmapOpt
+    # pass
+else if named stash-cache-auth
+    set GmapOpt = usemap
+else if named stash-origin-auth
+    set GmapOpt = usemap
+else
+    set GmapOpt = trymap
+fi
+

--- a/src/authfile-update
+++ b/src/authfile-update
@@ -89,13 +89,20 @@ class Download:
 
         self.full_destdir = f"{self.destdir}/{self.instance}"
         self.dest_file = f"{self.full_destdir}/{self.config_file}"
-        self.local_files = [
+        self.local_files = []
+        if config_file == "grid-mapfile":
+            # Local additions to the grid-mapfile are prepended, not appended
+            # to what's downloaded from topology because we want them to "win"
+            self.prepend_local = True
+
+            # Backward compat: also read /etc/grid-security/grid-mapfile
+            self.local_files.append("/etc/grid-security/grid-mapfile")
+        else:
+            self.prepend_local = False
+        self.local_files += [
             f"{self.destdir}/{self.instance}/{self.config_file}.local",
             f"/etc/xrootd/{self.instance}-{self.config_file}.local",
         ]
-        self.prepend_local = config_file == "grid-mapfile"
-        # ^^ local additions to the grid-mapfile are prepended, not appended
-        #    to what's downloaded from topology
 
     def fetch(self) -> Tuple[Optional[str], bool]:
         """Download the data for this config file from Topology and return

--- a/src/authfile-update
+++ b/src/authfile-update
@@ -144,6 +144,10 @@ class Download:
         new_text = ""
         for local_file in self.local_files:
             try:
+                if os.path.samefile(os.path.realpath(local_file), os.path.realpath(self.dest_file)):
+                    # The local file is a symlink to the destination file or something similar.
+                    # Skip it to avoid a loop.
+                    continue
                 with open(local_file, "rt", encoding="utf-8", errors="replace") as fh:
                     new_text += (
                         f"## The following lines are from {local_file}:\n"


### PR DESCRIPTION
Two changes necessary to actually use the grid-mapfile downloaded from Topology for the cache and origi n (instead of `/etc/grid-security/grid-mapfile`):

1. For backward compat, have authfile-update add local changed from /etc/grid-security/grid-mapfile to the downloaded mapfile
2. Set some variables in the XRootD config
The variables are necessary because the configs in the osg-xrootd metapackage are actually what control how the grid-mapfile is used, so we'll need to modify those to make use of the new variables here.