### PR TITLE
Import v2 python bindings

### DIFF
--- a/rpm/xcache.spec
+++ b/rpm/xcache.spec
@@ -1,6 +1,6 @@
 Name:      xcache
 Summary:   XCache scripts and configurations
-Version:   4.1.0
+Version:   4.1.1
 Release:   1%{?dist}
 License:   Apache 2.0
 Group:     Grid
@@ -259,6 +259,9 @@ mkdir -p %{buildroot}%{_sysconfdir}/grid-security/xrd
 %config %{_sysconfdir}/xrootd/config.d/03-redir-tuning.cfg
 
 %changelog
+* Tue Aug 11 2026 Matt Westphall <westphall@wisc.edu> - 4.1.1-1
+- Use HTCondor v2 python bindings (SOFTWARE-6233)
+
 * Thu Sep 11 2025 Mátyás Selmeci <mselmeci@wisc.edu> - 4.1.0-1
 - Enable ARM builds (except for xcache-consistency-check) (SOFTWARE-6057)
 - Dummy out xcache-consistency-check on OSG 25 and newer (SOFTWARE-6054)

--- a/src/test_xrootd_cache_stats.py
+++ b/src/test_xrootd_cache_stats.py
@@ -78,7 +78,7 @@ class TestStatsCollection(unittest.TestCase):
         ospathisdir = mock.Mock(side_effect=lambda path: os.path.basename(path) in ['a','b','c','d'])
         osstat = mock.Mock(return_value=mock.Mock(st_blocks=256))
 
-        import classad
+        import classad2 as classad
         scan_vo_dir = mock.Mock(return_value=classad.ClassAd("""
     [
         bytes_hr_24 = 524288;
@@ -117,7 +117,7 @@ class TestStatsCollection(unittest.TestCase):
 
     def test_collect_cache_stats(self):
 
-        import classad
+        import classad2 as classad
 
         mock_scan_cache_dirs = mock.Mock(return_value=classad.ClassAd({}))
         mock_test_xrootd_server = mock.Mock(return_value=classad.ClassAd({}))
@@ -135,4 +135,3 @@ class TestStatsCollection(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/src/xcache-reporter
+++ b/src/xcache-reporter
@@ -33,8 +33,8 @@ import time
 # Must set before importing XRootD.client
 #os.putenv('XRD_RUNFORKHANDLER', '1')
 
-import classad
-import htcondor
+import classad2 as classad
+import htcondor2 as htcondor
 import xrootd_cache_stats
 
 # Ad expires from collector after 15 minutes

--- a/src/xrootd_cache_stats.py
+++ b/src/xrootd_cache_stats.py
@@ -14,7 +14,7 @@ import collections
 import six
 from six.moves import urllib
 
-import classad
+import classad2 as classad
 import XRootD.client
 
 __all__ = ['collect_cache_stats']


### PR DESCRIPTION
Migration should be minimal, no deprecated binding features used. Used features:
- `htcondor.enable_debug()`
- `htcondor.Collector()`
- `htcondor.param`
- `classad.parseOne`
- `classad.ClassAd`